### PR TITLE
feat: Phase 3a — VM read + lifecycle tools (list_vms, get_vm, start/stop/restart_vm)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -155,10 +155,13 @@ truenas_mcp/
 **Goal**: Create, configure, start, stop, and delete VMs — needed for spinning up a PBS VM.
 
 **Tasks**:
-- [ ] `internal/truenas/vm.go` — list VMs, get VM, create VM, update VM, start/stop/restart/delete VM
-- [ ] `tools/vm.go` — read tools + lifecycle tools
+- [x] `internal/truenas/jobs.go` — async job type + PollJob helper
+- [x] `internal/truenas/vm.go` (3a) — list VMs, get VM, start/stop/restart VM
+- [ ] `internal/truenas/vm.go` (3b) — create VM, update VM
+- [x] `tools/vm.go` (3a) — `list_vms`, `get_vm`, `start_vm`, `stop_vm`, `restart_vm`
+- [ ] `tools/vm.go` (3b) — `create_vm`, `update_vm`
 - [ ] `tools/destructive.go` — opt-in `delete_vm`
-- [ ] Update README
+- [x] Update README (3a)
 
 **Tools delivered** (~8):
 `list_vms`, `get_vm`, `create_vm`, `update_vm`, `start_vm`, `stop_vm`, `restart_vm`, `delete_vm` (destructive)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ TRUENAS_INSECURE=true \
 | `get_dataset` | Get detailed information about a specific ZFS dataset or zvol by its full path | `id` (string, e.g. `Storage/backups`) |
 | `create_dataset` | Create a new ZFS dataset or zvol | `name` (string, required); `type`, `compression`, `comments`, `quota` (optional) |
 
+### Virtual Machines
+
+| Tool | Description | Parameters |
+|---|---|---|
+| `list_vms` | List all VMs and their state (RUNNING/STOPPED), CPU, and memory | _(none)_ |
+| `get_vm` | Get detailed information about a specific VM | `id` (int) |
+| `start_vm` | Start a VM; returns async job ID immediately | `id` (int) |
+| `stop_vm` | Stop a VM; set `force=true` to forcibly terminate | `id` (int); `force` (bool, optional) |
+| `restart_vm` | Restart a VM; returns async job ID immediately | `id` (int) |
+
 ## Development
 
 ```bash

--- a/internal/truenas/jobs.go
+++ b/internal/truenas/jobs.go
@@ -1,0 +1,66 @@
+package truenas
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const jobPollInterval = 2 * time.Second
+
+// JobProgress holds the current progress of a running TrueNAS job.
+type JobProgress struct {
+	Percent     float64 `json:"percent"`
+	Description string  `json:"description"`
+}
+
+// Job represents an async job returned by TrueNAS SCALE long-running operations.
+// The job ID is returned immediately by lifecycle operations; use PollJob to wait
+// for completion.
+type Job struct {
+	ID       int         `json:"id"`
+	Method   string      `json:"method"`
+	State    string      `json:"state"` // WAITING, RUNNING, SUCCESS, FAILED, ABORTED
+	Progress JobProgress `json:"progress"`
+	Error    *string     `json:"error"`
+}
+
+// getJobs fetches the job with the given ID from /core/get_jobs.
+func (c *Client) getJobs(ctx context.Context, id int) (*Job, error) {
+	path := fmt.Sprintf("/core/get_jobs?id=%d", id)
+	var jobs []Job
+	if err := c.get(ctx, path, &jobs); err != nil {
+		return nil, fmt.Errorf("fetching job %d: %w", id, err)
+	}
+	if len(jobs) == 0 {
+		return nil, fmt.Errorf("job %d not found", id)
+	}
+	return &jobs[0], nil
+}
+
+// PollJob polls the TrueNAS job API until the job reaches a terminal state
+// (SUCCESS, FAILED, or ABORTED) or the context is cancelled.
+// It returns the completed Job or an error if the job failed.
+func (c *Client) PollJob(ctx context.Context, id int) (*Job, error) {
+	for {
+		job, err := c.getJobs(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		switch job.State {
+		case "SUCCESS":
+			return job, nil
+		case "FAILED", "ABORTED":
+			msg := fmt.Sprintf("job %d %s", id, job.State)
+			if job.Error != nil {
+				msg += ": " + *job.Error
+			}
+			return nil, fmt.Errorf("%s", msg) //nolint:goerr113 // dynamic error is intentional: surfaces the remote job failure message
+		}
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("polling job %d: %w", id, ctx.Err())
+		case <-time.After(jobPollInterval):
+		}
+	}
+}

--- a/internal/truenas/vm.go
+++ b/internal/truenas/vm.go
@@ -1,0 +1,85 @@
+package truenas
+
+import (
+	"context"
+	"fmt"
+)
+
+// VMStatus holds the runtime state of a VM as reported by TrueNAS SCALE.
+type VMStatus struct {
+	State       string `json:"state"`        // RUNNING, STOPPED
+	PID         *int   `json:"pid"`          // nil when not running
+	DomainState string `json:"domain_state"` // libvirt domain state string
+}
+
+// VM represents a virtual machine configured on TrueNAS SCALE.
+type VM struct {
+	ID              int      `json:"id"`
+	Name            string   `json:"name"`
+	Description     string   `json:"description"`
+	VCPUs           int      `json:"vcpus"`
+	Memory          int      `json:"memory"` // MiB
+	Autostart       bool     `json:"autostart"`
+	Bootloader      string   `json:"bootloader"`
+	Cores           int      `json:"cores"`
+	Threads         int      `json:"threads"`
+	ShutdownTimeout int      `json:"shutdown_timeout"`
+	CPUMode         string   `json:"cpu_mode"`
+	CPUModel        string   `json:"cpu_model"`
+	UUID            string   `json:"uuid"`
+	Status          VMStatus `json:"status"`
+}
+
+// stopBody is the request body for the stop VM endpoint.
+type stopBody struct {
+	Force bool `json:"force"`
+}
+
+// ListVMs returns all virtual machines configured on the TrueNAS SCALE system.
+func (c *Client) ListVMs(ctx context.Context) ([]VM, error) {
+	var vms []VM
+	if err := c.get(ctx, "/vm", &vms); err != nil {
+		return nil, fmt.Errorf("listing VMs: %w", err)
+	}
+	return vms, nil
+}
+
+// GetVM returns a single VM by its numeric ID.
+func (c *Client) GetVM(ctx context.Context, id int) (*VM, error) {
+	var vm VM
+	if err := c.get(ctx, fmt.Sprintf("/vm/id/%d", id), &vm); err != nil {
+		return nil, fmt.Errorf("getting VM %d: %w", id, err)
+	}
+	return &vm, nil
+}
+
+// StartVM starts the VM with the given ID and returns the async job ID.
+// The job can be polled for completion using PollJob.
+func (c *Client) StartVM(ctx context.Context, id int) (int, error) {
+	var jobID int
+	if err := c.post(ctx, fmt.Sprintf("/vm/id/%d/start", id), &jobID); err != nil {
+		return 0, fmt.Errorf("starting VM %d: %w", id, err)
+	}
+	return jobID, nil
+}
+
+// StopVM stops the VM with the given ID and returns the async job ID.
+// Set force to true to forcibly terminate without a graceful shutdown.
+// The job can be polled for completion using PollJob.
+func (c *Client) StopVM(ctx context.Context, id int, force bool) (int, error) {
+	var jobID int
+	if err := c.postWithBody(ctx, fmt.Sprintf("/vm/id/%d/stop", id), stopBody{Force: force}, &jobID); err != nil {
+		return 0, fmt.Errorf("stopping VM %d: %w", id, err)
+	}
+	return jobID, nil
+}
+
+// RestartVM restarts the VM with the given ID and returns the async job ID.
+// The job can be polled for completion using PollJob.
+func (c *Client) RestartVM(ctx context.Context, id int) (int, error) {
+	var jobID int
+	if err := c.post(ctx, fmt.Sprintf("/vm/id/%d/restart", id), &jobID); err != nil {
+		return 0, fmt.Errorf("restarting VM %d: %w", id, err)
+	}
+	return jobID, nil
+}

--- a/internal/truenas/vm_test.go
+++ b/internal/truenas/vm_test.go
@@ -1,0 +1,177 @@
+package truenas
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListVMs_success(t *testing.T) {
+	t.Parallel()
+
+	want := []VM{
+		{
+			ID:     1,
+			Name:   "pbs",
+			VCPUs:  2,
+			Memory: 4096,
+			Status: VMStatus{State: "STOPPED"},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/vm" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(want); err != nil {
+			t.Errorf("encoding response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	got, err := c.ListVMs(context.Background())
+	if err != nil {
+		t.Fatalf("ListVMs: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 VM, got %d", len(got))
+	}
+	if got[0].Name != want[0].Name {
+		t.Errorf("Name = %q, want %q", got[0].Name, want[0].Name)
+	}
+	if got[0].Memory != want[0].Memory {
+		t.Errorf("Memory = %d, want %d", got[0].Memory, want[0].Memory)
+	}
+}
+
+func TestGetVM_success(t *testing.T) {
+	t.Parallel()
+
+	want := VM{
+		ID:     1,
+		Name:   "pbs",
+		VCPUs:  2,
+		Memory: 4096,
+		Status: VMStatus{State: "RUNNING"},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/vm/id/1" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(want); err != nil {
+			t.Errorf("encoding response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	got, err := c.GetVM(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetVM: %v", err)
+	}
+	if got.Name != want.Name {
+		t.Errorf("Name = %q, want %q", got.Name, want.Name)
+	}
+	if got.Status.State != want.Status.State {
+		t.Errorf("Status.State = %q, want %q", got.Status.State, want.Status.State)
+	}
+}
+
+func TestGetVM_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	_, err := c.GetVM(context.Background(), 99)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestStartVM_success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/vm/id/1/start" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(42); err != nil {
+			t.Errorf("encoding response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	jobID, err := c.StartVM(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("StartVM: %v", err)
+	}
+	if jobID != 42 {
+		t.Errorf("jobID = %d, want 42", jobID)
+	}
+}
+
+func TestStopVM_success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/vm/id/1/stop" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(43); err != nil {
+			t.Errorf("encoding response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	jobID, err := c.StopVM(context.Background(), 1, false)
+	if err != nil {
+		t.Fatalf("StopVM: %v", err)
+	}
+	if jobID != 43 {
+		t.Errorf("jobID = %d, want 43", jobID)
+	}
+}
+
+func TestRestartVM_success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/vm/id/1/restart" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(44); err != nil {
+			t.Errorf("encoding response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	jobID, err := c.RestartVM(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("RestartVM: %v", err)
+	}
+	if jobID != 44 {
+		t.Errorf("jobID = %d, want 44", jobID)
+	}
+}

--- a/tools/register.go
+++ b/tools/register.go
@@ -17,5 +17,6 @@ func RegisterAll(s *mcp.Server, client *truenas.Client, cfg Config) {
 	registerSystemTools(s, client)
 	registerPoolTools(s, client)
 	registerDatasetTools(s, client)
+	registerVMTools(s, client)
 	_ = cfg
 }

--- a/tools/vm.go
+++ b/tools/vm.go
@@ -1,0 +1,92 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+)
+
+// registerVMTools registers all VM-related MCP tools onto the server.
+func registerVMTools(s *mcp.Server, client *truenas.Client) {
+	type listVMsInput struct{}
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_vms",
+		Description: "List all virtual machines configured on the TrueNAS SCALE system, including their state (RUNNING/STOPPED), CPU, and memory.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ listVMsInput) (*mcp.CallToolResult, any, error) {
+		vms, err := client.ListVMs(ctx)
+		if err != nil {
+			return nil, nil, fmt.Errorf("list_vms: %w", err)
+		}
+		return jsonResult(vms)
+	})
+
+	type getVMInput struct {
+		ID int `json:"id" jsonschema:"Numeric VM ID"`
+	}
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_vm",
+		Description: "Get detailed information about a specific virtual machine by its numeric ID.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, p getVMInput) (*mcp.CallToolResult, any, error) {
+		vm, err := client.GetVM(ctx, p.ID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get_vm: %w", err)
+		}
+		return jsonResult(vm)
+	})
+
+	type startVMInput struct {
+		ID int `json:"id" jsonschema:"Numeric VM ID"`
+	}
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "start_vm",
+		Description: "Start a virtual machine by its numeric ID. Returns the async job ID immediately (non-blocking).",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, p startVMInput) (*mcp.CallToolResult, any, error) {
+		jobID, err := client.StartVM(ctx, p.ID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("start_vm: %w", err)
+		}
+		return jsonResult(map[string]int{"job_id": jobID})
+	})
+
+	type stopVMInput struct {
+		ID    int  `json:"id" jsonschema:"Numeric VM ID"`
+		Force bool `json:"force,omitempty" jsonschema:"Force-terminate the VM without a graceful shutdown; defaults to false"`
+	}
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "stop_vm",
+		Description: "Stop a virtual machine by its numeric ID. Set force=true to forcibly terminate without a graceful shutdown. Returns the async job ID immediately (non-blocking).",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, p stopVMInput) (*mcp.CallToolResult, any, error) {
+		jobID, err := client.StopVM(ctx, p.ID, p.Force)
+		if err != nil {
+			return nil, nil, fmt.Errorf("stop_vm: %w", err)
+		}
+		return jsonResult(map[string]int{"job_id": jobID})
+	})
+
+	type restartVMInput struct {
+		ID int `json:"id" jsonschema:"Numeric VM ID"`
+	}
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "restart_vm",
+		Description: "Restart a virtual machine by its numeric ID. Returns the async job ID immediately (non-blocking).",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, p restartVMInput) (*mcp.CallToolResult, any, error) {
+		jobID, err := client.RestartVM(ctx, p.ID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("restart_vm: %w", err)
+		}
+		return jsonResult(map[string]int{"job_id": jobID})
+	})
+}


### PR DESCRIPTION
## Summary

Implements Phase 3a: VM read and lifecycle tools. Phase 3b (create_vm, update_vm, delete_vm) follows in the next PR to stay under the 500-line limit.

## Changes

- `internal/truenas/jobs.go` — `Job`/`JobProgress` types and `PollJob` helper for polling async TrueNAS jobs; ready for use by `create_vm` in 3b
- `internal/truenas/vm.go` — `VM`/`VMStatus` types; `ListVMs`, `GetVM`, `StartVM`, `StopVM` (with `force` option), `RestartVM` client methods
- `internal/truenas/vm_test.go` — httptest unit tests for all 5 client methods
- `tools/vm.go` — `list_vms`, `get_vm`, `start_vm`, `stop_vm`, `restart_vm` MCP tools; lifecycle tools return `{"job_id": N}` immediately (non-blocking)
- `tools/register.go` — wire `registerVMTools`
- `README.md` — add Virtual Machines tools table
- `PLAN.md` — mark Phase 3a tasks complete; 3b items remain

## Quality Gates

- `make check` passes: 0 lint issues, 0 gosec issues, 0 vulnerabilities
- All tests pass with `-race`
- 437 lines changed (under 500-line PR limit)

## Tools Delivered

| Tool | Description |
|---|---|
| `list_vms` | List all VMs with state, CPU, memory |
| `get_vm` | Get a VM by numeric ID |
| `start_vm` | Start a VM; returns async job ID |
| `stop_vm` | Stop a VM (graceful or forced); returns async job ID |
| `restart_vm` | Restart a VM; returns async job ID |