### PR TITLE
Phase 8: README installation section + PLAN.md completion status

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -317,7 +317,7 @@ tooling — just download a binary and configure `mcp.json`.
 
 - [x] `ci.yml` passes on `main` for both repos
 - [x] `release.yml` produces binaries on a `v*` tag for both repos
-- [ ] README installation section complete for both repos
+- [x] README installation section complete for both repos
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -11,6 +11,26 @@ Uses the official `modelcontextprotocol/go-sdk`, a custom TrueNAS REST API HTTP 
 cross-product workflows — the first target being provisioning a Proxmox Backup Server (PBS)
 VM on TrueNAS SCALE automatically from the Proxmox MCP.
 
+## Plan Status
+
+**Phases 1–8 complete.** All planned tools are shipped, CI and release workflows are in
+place, and the README is up to date.
+
+Phase 9 (WebSocket API migration) is defined below but not yet scheduled. New phases will
+be added here when the next area of work is planned.
+
+| Phase | Status |
+|---|---|
+| 1 — Foundation | ✅ Complete |
+| 2 — Pools & Datasets | ✅ Complete |
+| 3 — VMs | ✅ Complete |
+| 4 — Docker Containers | ✅ Complete |
+| 5 — Snapshots | ✅ Complete |
+| 6 — Apps Rename + Upgrade/Rollback | ✅ Complete |
+| 7 — PBS Workflow validation | ✅ Complete |
+| 8 — CI & Releases | ✅ Complete |
+| 9 — WebSocket API Migration | ⏳ Not yet scheduled |
+
 ## Decisions
 
 | Decision | Choice | Rationale |
@@ -120,14 +140,14 @@ truenas_mcp/
 **Goal**: Working binary, client, auth, and basic read-only tools.
 
 **Tasks**:
-- [ ] `go mod init`, add MCP SDK dependency
-- [ ] Copy `.golangci.yml` and `Makefile` from proxmox-mcp (same rules)
-- [ ] Implement `internal/truenas/client.go` — HTTP client, API key auth, TLS opt-out, context timeouts
-- [ ] Implement `internal/truenas/jobs.go` — poll `/core/get_jobs` until job completes
-- [ ] Implement `internal/truenas/system.go` — `/system/info`, `/system/version`
-- [ ] Implement `tools/system.go` — `get_system_info` tool
-- [ ] Implement `cmd/truenas-mcp/main.go` — flags, env, wire-up, stdio + HTTP transports
-- [ ] `make check` passes
+- [x] `go mod init`, add MCP SDK dependency
+- [x] Copy `.golangci.yml` and `Makefile` from proxmox-mcp (same rules)
+- [x] Implement `internal/truenas/client.go` — HTTP client, API key auth, TLS opt-out, context timeouts
+- [x] Implement `internal/truenas/jobs.go` — poll `/core/get_jobs` until job completes
+- [x] Implement `internal/truenas/system.go` — `/system/info`, `/system/version`
+- [x] Implement `tools/system.go` — `get_system_info` tool
+- [x] Implement `cmd/truenas-mcp/main.go` — flags, env, wire-up, stdio + HTTP transports
+- [x] `make check` passes
 
 **Tools delivered** (~2):
 `get_system_info`, `get_system_version`

--- a/README.md
+++ b/README.md
@@ -74,17 +74,19 @@ Download the latest release for your platform from the [Releases](https://github
 | Platform | Binary |
 |---|---|
 | Linux (amd64) | `truenas-mcp_linux_amd64` |
-| Linux (ARM64) | `truenas-mcp_linux_arm64` |
-| macOS (Intel) | `truenas-mcp_darwin_amd64` |
-| macOS (Apple Silicon) | `truenas-mcp_darwin_arm64` |
-| Windows | `truenas-mcp_windows_amd64.exe` |
+| Linux (arm64) | `truenas-mcp_linux_arm64` |
+| macOS (amd64) | `truenas-mcp_darwin_amd64` |
+| macOS (arm64) | `truenas-mcp_darwin_arm64` |
+| Windows (amd64) | `truenas-mcp_windows_amd64.exe` |
 
-Make it executable and place it on your `PATH`:
+Make it executable and place it on your `PATH` (substitute the filename for your platform):
 
 ```bash
-chmod +x truenas-mcp_linux_amd64
-mv truenas-mcp_linux_amd64 /usr/local/bin/truenas-mcp
+chmod +x <binary-name>
+mv <binary-name> /usr/local/bin/truenas-mcp
 ```
+
+> Windows users: rename the `.exe` and add it to a directory on your `%PATH%`.
 
 ### Build from source
 
@@ -93,7 +95,9 @@ Requires Go 1.26+. You will also need a TrueNAS SCALE instance and an API key â€
 ```bash
 git clone https://github.com/gordcurrie/truenas-mcp
 cd truenas-mcp
-make build   # binary lands in bin/truenas-mcp
+cp .env.example .env   # copy the example env file
+$EDITOR .env           # set TRUENAS_* values (see table below)
+make build             # binary lands in bin/truenas-mcp
 ```
 
 ## Configuration
@@ -253,5 +257,5 @@ make install-tools   # install golangci-lint, gosec, govulncheck, gofumpt
 make check           # full quality gate: fix, fmt, vet, lint, sec, vulncheck, test, build
 make test            # tests only (with race detector)
 make build           # build only â†’ bin/truenas-mcp
-make clean           # remove bin/
+make clean           # remove bin/truenas-mcp
 ```

--- a/README.md
+++ b/README.md
@@ -2,53 +2,6 @@
 
 An MCP server that exposes [TrueNAS SCALE](https://www.truenas.com/truenas-scale/) operations as MCP tools, written in Go.
 
-## Setup
-
-### Prerequisites
-
-- Go 1.26+
-- A TrueNAS SCALE instance
-- An API key (create one in TrueNAS UI under **Credentials → API Keys**)
-
-### Environment Variables
-
-| Variable | Required | Description |
-|---|---|---|
-| `TRUENAS_API_URL` | yes | e.g. `https://truenas.local/api/v2.0` |
-| `TRUENAS_API_KEY` | yes | API key from TrueNAS UI |
-| `TRUENAS_INSECURE` | no | `true` to skip TLS verification (self-signed certs) |
-| `TRUENAS_ALLOW_DESTRUCTIVE` | no | `true` to enable destructive tools (default: disabled) |
-
-### Running
-
-```bash
-# stdio (default — for use with MCP clients like Claude Desktop / VS Code Copilot)
-TRUENAS_API_URL=https://truenas.local/api/v2.0 \
-TRUENAS_API_KEY=your-api-key \
-TRUENAS_INSECURE=true \
-./bin/truenas-mcp
-
-# HTTP transport
-./bin/truenas-mcp --transport http --addr localhost:8081
-```
-
-### VS Code / Claude Desktop config
-
-```json
-{
-  "mcpServers": {
-    "truenas": {
-      "command": "/path/to/truenas-mcp",
-      "env": {
-        "TRUENAS_API_URL": "https://truenas.local/api/v2.0",
-        "TRUENAS_API_KEY": "your-api-key",
-        "TRUENAS_INSECURE": "true"
-      }
-    }
-  }
-}
-```
-
 ## Tools
 
 ### System
@@ -111,6 +64,124 @@ TRUENAS_INSECURE=true \
 | `delete_vm` | Permanently delete a stopped VM | `id` (int); `confirmed: true` (required) |
 | `delete_app` | Permanently delete a TrueNAS app | `name` (string); `confirmed: true` (required) |
 | `delete_snapshot` | Permanently delete a ZFS snapshot | `id` (string, e.g. `Storage/backups@before-upgrade`); `confirmed: true` (required) |
+
+## Installation
+
+### Download a pre-built binary
+
+Download the latest release for your platform from the [Releases](https://github.com/gordcurrie/truenas-mcp/releases) page.
+
+| Platform | Binary |
+|---|---|
+| Linux (amd64) | `truenas-mcp_linux_amd64` |
+| Linux (ARM64) | `truenas-mcp_linux_arm64` |
+| macOS (Intel) | `truenas-mcp_darwin_amd64` |
+| macOS (Apple Silicon) | `truenas-mcp_darwin_arm64` |
+| Windows | `truenas-mcp_windows_amd64.exe` |
+
+Make it executable and place it on your `PATH`:
+
+```bash
+chmod +x truenas-mcp_linux_amd64
+mv truenas-mcp_linux_amd64 /usr/local/bin/truenas-mcp
+```
+
+### Build from source
+
+Requires Go 1.26+. You will also need a TrueNAS SCALE instance and an API key — create one in the TrueNAS UI under **Credentials → API Keys**.
+
+```bash
+git clone https://github.com/gordcurrie/truenas-mcp
+cd truenas-mcp
+make build   # binary lands in bin/truenas-mcp
+```
+
+## Configuration
+
+All configuration is via environment variables:
+
+| Variable | Required | Description |
+|---|---|---|
+| `TRUENAS_API_URL` | yes | e.g. `https://truenas.local/api/v2.0` |
+| `TRUENAS_API_KEY` | yes | API key from TrueNAS UI |
+| `TRUENAS_INSECURE` | no | `true` to skip TLS verification (self-signed certs) |
+| `TRUENAS_ALLOW_DESTRUCTIVE` | no | `true` to enable destructive tools (default: disabled) |
+
+## MCP Client Setup
+
+### Running
+
+```bash
+# stdio (default — for use with local MCP clients)
+TRUENAS_API_URL=https://truenas.local/api/v2.0 \
+TRUENAS_API_KEY=your-api-key \
+./truenas-mcp
+
+# HTTP transport (for remote or shared deployments)
+./truenas-mcp --transport http --addr localhost:8081
+```
+
+### VS Code Copilot
+
+Create `.vscode/mcp.json` in your workspace (already gitignored):
+
+```json
+{
+  "servers": {
+    "truenas": {
+      "type": "stdio",
+      "command": "/path/to/truenas-mcp",
+      "env": {
+        "TRUENAS_API_URL": "https://truenas.local/api/v2.0",
+        "TRUENAS_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+Then open the Copilot chat panel, switch to **Agent** mode, and the `truenas` server will appear in the available tools.
+
+### Claude Desktop
+
+Add the server to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "truenas": {
+      "command": "/path/to/truenas-mcp",
+      "env": {
+        "TRUENAS_API_URL": "https://truenas.local/api/v2.0",
+        "TRUENAS_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving the config.
+
+### OpenCode
+
+Add the server to `opencode.json` in your project root (or `~/.config/opencode/opencode.json` for global config):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "truenas": {
+      "type": "local",
+      "command": ["/path/to/truenas-mcp"],
+      "enabled": true,
+      "environment": {
+        "TRUENAS_API_URL": "https://truenas.local/api/v2.0",
+        "TRUENAS_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
 
 ## Worked Example — Proxmox Backup Server on TrueNAS
 
@@ -178,8 +249,9 @@ Steps 1–4 are fully automated today. Steps 5–6 require future proxmox-mcp to
 ## Development
 
 ```bash
-make install-tools   # install gofumpt, gosec, govulncheck, golangci-lint
-make check           # run all quality gates (fmt, vet, lint, sec, vulncheck, test, build)
-make build           # build binary to bin/truenas-mcp
-make test            # run tests with race detector
+make install-tools   # install golangci-lint, gosec, govulncheck, gofumpt
+make check           # full quality gate: fix, fmt, vet, lint, sec, vulncheck, test, build
+make test            # tests only (with race detector)
+make build           # build only → bin/truenas-mcp
+make clean           # remove bin/
 ```


### PR DESCRIPTION
## Phase 8 final: README audit + PLAN.md completion\n\n### README changes\n\n- **Restructured**: Tools section moved to the top (before setup), consistent with proxmox-mcp\n- **Installation section added**: binary download table (5 platforms) + build from source instructions\n- **Configuration section**: extracted into its own `##` section (was nested under Setup)\n- **MCP Client Setup section**: split VS Code, Claude Desktop, and OpenCode into separate subsections\n- **VS Code config fixed**: was using `mcpServers` (Claude Desktop format); corrected to `servers` / `type: stdio`\n- **OpenCode config added**: was missing entirely\n- **Development section aligned**: matches proxmox-mcp formatting and command descriptions\n\n### PLAN.md changes\n\n- Added **Plan Status** section with phase completion table (Phases 1–8 ✅, Phase 9 ⏳ not yet scheduled)\n- Fixed Phase 1 task items: all were `[ ]` from initial planning but were delivered in the first PR — marked `[x]`