### PR TITLE
fix: nest dtype inside attributes for add_vm_device API call

### DIFF
--- a/internal/truenas/vm.go
+++ b/internal/truenas/vm.go
@@ -3,6 +3,7 @@ package truenas
 import (
 	"context"
 	"fmt"
+	"maps"
 	"regexp"
 )
 
@@ -221,6 +222,14 @@ type AddVMDeviceParams struct {
 	Order      *int           `json:"order,omitempty"`
 }
 
+// addVMDeviceWire is the JSON shape the TrueNAS API actually expects:
+// dtype lives inside attributes, not at the top level.
+type addVMDeviceWire struct {
+	VMID       int            `json:"vm"`
+	Attributes map[string]any `json:"attributes"`
+	Order      *int           `json:"order,omitempty"`
+}
+
 // ListVMDevices returns all devices attached to the VM with the given ID.
 // It fetches all devices from the API and filters them by VM ID client-side.
 func (c *Client) ListVMDevices(ctx context.Context, vmID int) ([]VMDevice, error) {
@@ -254,8 +263,20 @@ func (c *Client) AddVMDevice(ctx context.Context, params *AddVMDeviceParams) (*V
 		return nil, fmt.Errorf("adding VM device: attributes must not be empty")
 	}
 
+	// The TrueNAS API expects dtype inside the attributes map, not as a
+	// top-level field. Build the wire payload accordingly.
+	attrs := make(map[string]any, len(params.Attributes)+1)
+	maps.Copy(attrs, params.Attributes)
+	attrs["dtype"] = string(params.DType)
+
+	wire := addVMDeviceWire{
+		VMID:       params.VMID,
+		Attributes: attrs,
+		Order:      params.Order,
+	}
+
 	var device VMDevice
-	if err := c.postWithBody(ctx, "/vm/device", params, &device); err != nil {
+	if err := c.postWithBody(ctx, "/vm/device", wire, &device); err != nil {
 		return nil, fmt.Errorf("adding %s device to VM %d: %w", params.DType, params.VMID, err)
 	}
 	return &device, nil

--- a/internal/truenas/vm.go
+++ b/internal/truenas/vm.go
@@ -265,6 +265,11 @@ func (c *Client) AddVMDevice(ctx context.Context, params *AddVMDeviceParams) (*V
 
 	// The TrueNAS API expects dtype inside the attributes map, not as a
 	// top-level field. Build the wire payload accordingly.
+	// Reject ambiguous input: DType is the authoritative source for dtype.
+	// Callers must not set "dtype" inside Attributes directly.
+	if _, conflict := params.Attributes["dtype"]; conflict {
+		return nil, fmt.Errorf("adding VM device: dtype must be set via DType, not inside Attributes")
+	}
 	attrs := make(map[string]any, len(params.Attributes)+1)
 	maps.Copy(attrs, params.Attributes)
 	attrs["dtype"] = string(params.DType)

--- a/internal/truenas/vm_test.go
+++ b/internal/truenas/vm_test.go
@@ -414,6 +414,23 @@ func TestAddVMDevice_success(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
+
+		// Assert wire format: dtype must be inside attributes, not top-level.
+		var body map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding request body: %v", err)
+		}
+		if _, topLevel := body["dtype"]; topLevel {
+			t.Errorf("dtype must not appear as a top-level field in the request body")
+		}
+		var attrs map[string]any
+		if err := json.Unmarshal(body["attributes"], &attrs); err != nil {
+			t.Errorf("decoding attributes: %v", err)
+		}
+		if attrs["dtype"] != string(VMDeviceTypeCDROM) {
+			t.Errorf("attributes.dtype = %v, want %q", attrs["dtype"], VMDeviceTypeCDROM)
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(want); err != nil {
 			t.Errorf("encoding response: %v", err)

--- a/internal/truenas/vm_test.go
+++ b/internal/truenas/vm_test.go
@@ -419,6 +419,8 @@ func TestAddVMDevice_success(t *testing.T) {
 		var body map[string]json.RawMessage
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Errorf("decoding request body: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
 		}
 		if _, topLevel := body["dtype"]; topLevel {
 			t.Errorf("dtype must not appear as a top-level field in the request body")
@@ -426,6 +428,8 @@ func TestAddVMDevice_success(t *testing.T) {
 		var attrs map[string]any
 		if err := json.Unmarshal(body["attributes"], &attrs); err != nil {
 			t.Errorf("decoding attributes: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
 		}
 		if attrs["dtype"] != string(VMDeviceTypeCDROM) {
 			t.Errorf("attributes.dtype = %v, want %q", attrs["dtype"], VMDeviceTypeCDROM)
@@ -468,6 +472,7 @@ func TestAddVMDevice_validation(t *testing.T) {
 		{"zero vmid", &AddVMDeviceParams{VMID: 0, DType: VMDeviceTypeDISK, Attributes: map[string]any{"path": "zvol/x"}}},
 		{"empty dtype", &AddVMDeviceParams{VMID: 1, DType: "", Attributes: map[string]any{"path": "zvol/x"}}},
 		{"empty attributes", &AddVMDeviceParams{VMID: 1, DType: VMDeviceTypeDISK, Attributes: map[string]any{}}},
+		{"dtype in attributes", &AddVMDeviceParams{VMID: 1, DType: VMDeviceTypeDISK, Attributes: map[string]any{"dtype": "DISK", "path": "zvol/x"}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #14

## Problem

`add_vm_device` always returned a 422 from the TrueNAS API because `dtype` was serialised as a top-level field in the request body. The actual API shape requires `dtype` inside `attributes`.

**Sent (wrong):**
```json
{ "vm": 2, "dtype": "DISK", "attributes": { "path": "...", "type": "VIRTIO" } }
```

**Expected (correct):**
```json
{ "vm": 2, "attributes": { "dtype": "DISK", "path": "...", "type": "VIRTIO" } }
```

## Changes

- Added `addVMDeviceWire` internal struct with `attributes`-only payload (no top-level `dtype`)
- `AddVMDevice` now copies `params.Attributes` into a new map, injects `dtype`, and sends the wire struct
- `TestAddVMDevice_success` now decodes the request body and asserts `dtype` is inside `attributes` and absent at the top level