### PR TITLE
fix(review): critical fixes and R1, R4, R6 improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ vulncheck:
 test:
 	go test -race -count=1 ./...
 
-## build – compile the binary
+## build – compile the binary, injecting the version from the current git tag
 build:
 	@mkdir -p bin
-	go build -o $(BINARY) $(CMD)
+	go build -ldflags "-X main.version=$$(git describe --tags --always --dirty 2>/dev/null || echo dev)" -o $(BINARY) $(CMD)
 
 ## check – run all quality gates in order (pre-commit gate)
 check: fix fmt vet lint sec vulncheck test build

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,41 +2,93 @@
 
 ## Summary
 
-Go MCP server exposing TrueNAS SCALE operations as tools. Uses `modelcontextprotocol/go-sdk`,
-a custom `net/http` REST client (no third-party TrueNAS library), API key auth, and strict
-linting via `golangci-lint`/`gosec`/`govulncheck`. Primary goal: allow AI agents to configure
-TrueNAS SCALE as part of the Proxmox backup workflow.
+Build an MCP server in Go that exposes TrueNAS SCALE operations as MCP tools.
+Uses the official `modelcontextprotocol/go-sdk`, a custom TrueNAS REST API HTTP client
+(no third-party TrueNAS library), API key auth, and strict linting enforced via
+`golangci-lint`, `gosec`, `govulncheck`, and `go fix`.
 
-## Plan Status
-
-| Phase | Status |
-|---|---|
-| 1–8 (Foundation through CI & Releases) | ✅ Complete — 32 tools shipped |
-| PR — VM Device Management | ✅ Complete — 35 tools shipped |
-| PR — Safety & Quality Fixes | ✅ Complete — 35 tools shipped |
-| 9 — WebSocket API Migration | ⏳ Before TrueNAS v26.04 (~mid-2026) |
-| 10 — NFS Share Management | 🔜 After safety PR (Proxmox backup workflow) |
+**Primary motivation**: Allow AI agents to configure TrueNAS SCALE as part of larger
+cross-product workflows — the first target being provisioning a Proxmox Backup Server (PBS)
+VM on TrueNAS SCALE automatically from the Proxmox MCP.
 
 ## Decisions
 
 | Decision | Choice | Rationale |
 |---|---|---|
 | MCP SDK | `github.com/modelcontextprotocol/go-sdk` | Official Go SDK, same as proxmox-mcp |
-| TrueNAS client | Custom `net/http` wrapper | Full control, no external dep |
-| Auth | API key (`Authorization: Bearer <key>`) | Stateless, no session tokens |
-| Transports | stdio (default) + HTTP (`--transport=http`) | stdio for local clients, HTTP for remote |
-| Formatter | `gofumpt` | Stricter than `gofmt` |
-| TLS | Verify on by default; `TRUENAS_INSECURE=true` to skip | TrueNAS commonly uses self-signed certs |
-| Destructive tools | Opt-in via `TRUENAS_ALLOW_DESTRUCTIVE=true` | Safe by default |
+| TrueNAS client | Custom `net/http` wrapper | Full control, no external dep, easy to extend |
+| Auth | API key (`Authorization: Bearer <key>`) | Stateless, no session tokens, matches TrueNAS REST auth |
+| Transports | Both stdio + HTTP (flag-selected) | stdio for local clients, HTTP for remote/shared |
+| Linter | `golangci-lint` + `gosec` + `govulncheck` | Security-first, idiomatic Go — same as proxmox-mcp |
+| Formatter | `gofumpt` (stricter than `gofmt`) | Consistent style |
+| TLS | `TRUENAS_INSECURE=true` opt-in for skip-verify | TrueNAS commonly uses self-signed certs on LAN |
+| Error handling | Always wrap with `fmt.Errorf("doing X: %w", err)` | Idiomatic, stack-traceable |
+| Global state | None — client injected, no `init()` | Testable, explicit |
+
+## TrueNAS SCALE API Notes
+
+- Base URL: `https://<host>/api/v2.0`
+- All endpoints return JSON directly (no `{"data": ...}` wrapper, unlike Proxmox)
+- Auth header: `Authorization: Bearer <api-key>`
+- Long-running operations return a job ID (`{"id": 123}`) — poll `/core/get_jobs?id=<id>`
+  for completion, same pattern as Proxmox UPIDs
+- API docs available at `https://<host>/api/docs/` on any TrueNAS SCALE instance
+- API key is created in the TrueNAS UI under Credentials → API Keys
+
+## Project Structure
+
+```
+truenas_mcp/
+├── cmd/
+│   └── truenas-mcp/
+│       └── main.go               # entrypoint, CLI flags, transport selection
+├── internal/
+│   └── truenas/
+│       ├── client.go             # custom HTTP client (auth, TLS, base URL)
+│       ├── client_test.go        # httptest-based unit tests
+│       ├── types.go              # shared TrueNAS response/request structs
+│       ├── types_test.go
+│       ├── system.go             # system info API calls
+│       ├── system_test.go
+│       ├── pool.go               # storage pool API calls
+│       ├── pool_test.go
+│       ├── dataset.go            # dataset/zvol API calls
+│       ├── dataset_test.go
+│       ├── snapshot.go           # ZFS snapshot API calls
+│       ├── snapshot_test.go
+│       ├── vm.go                 # VM API calls
+│       ├── vm_test.go
+│       ├── app.go                # TrueNAS Apps (Docker/catalog) API calls
+│       ├── app_test.go
+│       └── jobs.go               # async job polling (/core/get_jobs)
+│           jobs_test.go
+├── tools/
+│   ├── register.go               # RegisterAll(cfg Config) wires all tools onto the MCP server
+│   ├── helpers.go                # shared tool helpers
+│   ├── helpers_test.go
+│   ├── system.go                 # system info MCP tools
+│   ├── pool.go                   # storage pool MCP tools
+│   ├── dataset.go                # dataset MCP tools
+│   ├── snapshot.go               # snapshot MCP tools
+│   ├── vm.go                     # VM MCP tools
+│   ├── app.go                    # TrueNAS Apps MCP tools
+│   └── destructive.go            # delete_dataset, delete_vm, delete_snapshot (opt-in)
+├── .golangci.yml                 # linter config (copy from proxmox-mcp, same rules)
+├── Makefile                      # quality gate targets (same targets as proxmox-mcp)
+├── go.mod
+├── go.sum
+├── README.md
+└── PLAN.md                       # this file
+```
 
 ## Environment Variables
 
 | Variable | Required | Description |
 |---|---|---|
-| `TRUENAS_API_URL` | yes | e.g. `https://truenas.local/api/v2.0` |
-| `TRUENAS_API_KEY` | yes | API key from TrueNAS UI → Credentials → API Keys |
-| `TRUENAS_INSECURE` | no | `true` to skip TLS verification |
-| `TRUENAS_ALLOW_DESTRUCTIVE` | no | `true` to register destructive tools |
+| `TRUENAS_API_URL` | yes | Base URL, e.g. `https://truenas.local/api/v2.0` |
+| `TRUENAS_API_KEY` | yes | API key created in TrueNAS UI under Credentials → API Keys |
+| `TRUENAS_INSECURE` | no | Set `true` to skip TLS verification (self-signed certs) |
+| `TRUENAS_ALLOW_DESTRUCTIVE` | no | Set `true` to register `delete_dataset`, `delete_vm`, `delete_snapshot` (default: disabled) |
 
 ## CLI Flags
 
@@ -47,299 +99,148 @@ TrueNAS SCALE as part of the Proxmox backup workflow.
 
 ## Makefile Targets
 
-`make fix` → `make fmt` → `make vet` → `make lint` → `make sec` → `make vulncheck` →
-`make test` → `make build` — all run by `make check`.
+| Target | What it does |
+|---|---|
+| `make fix` | `go fix ./...` |
+| `make fmt` | `gofumpt -w .` |
+| `make vet` | `go vet ./...` |
+| `make lint` | `golangci-lint run ./...` |
+| `make sec` | `gosec ./...` |
+| `make vulncheck` | `govulncheck ./...` |
+| `make test` | `go test -race -count=1 ./...` |
+| `make build` | `go build ./cmd/truenas-mcp/` |
+| `make check` | runs all of the above in order |
 
-## TrueNAS API Notes
-
-- Base URL: `https://<host>/api/v2.0`
-- Responses are direct JSON — no `{"data": ...}` envelope (unlike Proxmox)
-- Auth header: `Authorization: Bearer <api-key>`
-- Long-running operations return a job ID — poll `/core/get_jobs?id=<id>` for completion
-- API docs: `https://<host>/api/docs/` on any TrueNAS SCALE instance
-
----
-
-## PR — VM Device Management ✅
-
-**Goal**: Allow agents to attach and manage hardware devices on TrueNAS SCALE VMs — disks,
-CDROMs (ISO files), NICs, and displays — so a VM can be fully configured via MCP without
-using the TrueNAS web UI.
-
-### New tools (3)
-
-| Tool | API endpoint | Description |
-|---|---|---|
-| `list_vm_devices` | `GET /vm/device` | List all devices on a VM, filtered by VM ID |
-| `add_vm_device` | `POST /vm/device` | Attach a DISK, CDROM, NIC, or DISPLAY device |
-| `delete_vm_device` | `DELETE /vm/device/id/{id}` | Remove a device by its device ID |
-
-### Note — `install_custom_app` visibility
-
-`install_custom_app` is registered in the server and works correctly. If it does not appear
-in Copilot's available tools, do a **full VS Code restart** (not just MCP server restart).
-Copilot caches the tool list per-connection; a stale connection from before the tool was
-added to the binary will not see it until the cache is cleared.
-
-**Tool count:** 32 + 3 = **35 tools**
+## Implementation Phases
 
 ---
 
-## PR — Safety & Quality Fixes
+### Phase 1 — Foundation (bootstrapping + system info)
 
-**Goal**: Address critical safety, correctness, and maintainability issues identified in the
-MCP expert review before any new feature work begins. No new tools are added; no public
-interfaces change.
+**Goal**: Working binary, client, auth, and basic read-only tools.
 
-> **Why 6/10?** The architecture and Go idioms are genuinely strong. The score reflects
-> one real data-safety gap (`rollback_snapshot` can destroy datasets through an agent with
-> no confirmation), a timer leak in the job poller, misleading security-audit comments that
-> undermine the `//nolint` review trail, and missing input validation on integer IDs. These
-> are not cosmetic — they are the difference between a server you can trust to run
-> unsupervised and one you cannot. Fix these and the baseline comfortably reaches 8+.
-
----
-
-### Critical — Must Fix
-
-#### C1: `rollback_snapshot` is missing the destructive gate
-
-`rollback_snapshot` destroys all ZFS data written after the target snapshot point. It is at
-least as destructive as `delete_snapshot`, which already requires all three safety layers.
-Currently `rollback_snapshot` sits in `registerSnapshotTools`, has no `confirmed bool`
-guard, no `DestructiveHint`, and is registered even when `TRUENAS_ALLOW_DESTRUCTIVE=false`.
-An LLM agent can call it silently in a default configuration.
-
-**Tasks:**
-- [ ] Move `rollback_snapshot` out of `tools/snapshot.go` into `tools/destructive.go`
-- [ ] Add `Confirmed bool` field (`jsonschema:"required,..."`) to `rollbackSnapshotInput`
-- [ ] Return early with an error when `!p.Confirmed`
-- [ ] Add `DestructiveHint: &destructiveHint` to the tool annotations
-- [ ] Update README destructive table and PLAN.md tool count if reclassification changes the numbers
-
-#### C2: Stale Proxmox copy-paste in `client.go` comments
-
-Three places in `internal/truenas/client.go` reference the Proxmox project this was forked
-from. This directly undermines the audit trail for `//nolint` directives — a reviewer
-checking the `gosec` annotation will see the wrong env var name and reasonably conclude the
-justification was not reviewed for this codebase.
-
-**Tasks:**
-- [x] `//nolint:gosec` on `InsecureSkipVerify`: change `PROXMOX_INSECURE` → `TRUENAS_INSECURE`
-- [x] `//nolint:gosec` on `httpClient.Do`: change `PROXMOX_API_URL` → `TRUENAS_API_URL`
-- [x] `post()` doc comment: remove the sentence referencing the Proxmox `{"data": ...}` envelope
-
-#### C3: Timer leak in `PollJob`
-
-`time.After` in a loop allocates a new timer every iteration. The timer has a 2-second fuse
-and is not garbage-collected until it fires. If the loop exits early (context cancelled, job
-succeeded, job failed), the current-iteration timer leaks until it fires. Under concurrent
-job polling this accumulates.
-
-**Tasks:**
-- [x] Replace `time.After(jobPollInterval)` with a `time.NewTimer` created once before the
-  loop, stopped via `defer timer.Stop()`, and reset at the top of each iteration using
-  `timer.Reset(jobPollInterval)` (drain the channel first if needed to avoid stale tick)
-- [x] Update `jobs_test.go` if the timing behaviour changes
-
-#### C4: Zero-value integer IDs are not validated
-
-`get_vm`, `get_pool`, `list_vm_devices`, and `add_vm_device` accept `id int`. Go's zero
-value is `0`; if an LLM omits the field or passes `null`, the server silently issues a real
-HTTP request to `/vm/id/0`. No TrueNAS resource ever has ID 0.
-
-**Tasks:**
-- [x] Add `if p.ID <= 0 { return nil, nil, errors.New("...: id must be a positive integer") }`
-  at the top of each affected handler in `tools/vm.go` and `tools/pool.go`
-- [x] Apply the same guard in `tools/destructive.go` for `deleteVMInput` and `deleteVMDeviceInput`
-
----
-
-### Recommended — High Value
-
-#### R1: `list_snapshots` fetches all snapshots then filters in Go
-
-A large NAS instance may have thousands of snapshots. The full list is transferred over the
-wire and decoded before the dataset filter is applied. TrueNAS v2 supports server-side query
-filters.
-
-**Tasks:**
-- [x] When `dataset != ""`, request
-  `GET /pool/snapshot?query-filters=[["dataset","=","<dataset>"]]` instead of fetching all
-- [x] Update `ListSnapshots` in `internal/truenas/snapshot.go`
-- [x] Update `snapshot_test.go`
-
-#### R2: HTTP graceful shutdown has no timeout
-
-`httpServer.Shutdown(context.Background())` in `cmd/truenas-mcp/main.go` waits forever for
-active connections to drain if a client holds a streaming connection open.
-
-**Tasks:**
-- [x] Replace `context.Background()` with `context.WithTimeout(context.Background(), 10*time.Second)`
-- [x] `defer cancel()` the returned cancel function
-
-#### R3: `update_vm` memory validation is effectively a no-op
-
-The guard `params.Memory < 0` never triggers in practice because `Memory int` with
-`omitempty` means 0 (the zero value) is never serialised. The validation looks correct but
-does not protect against the actual edge case.
-
-**Tasks:**
-- [x] The correct rule is: if Memory is provided it must be > 0; since 0 means "unchanged"
-  (omitted by `omitempty`), only negative values need to be rejected — add a comment
-  explaining this clearly so the next reader does not remove it as dead code
-- [x] Confirm the positive guard in `CreateVM` is intentional and add a matching comment
-
-#### R4: Required string inputs in tool handlers have no blank-check
-
-Tools such as `get_app`, `get_dataset`, `create_snapshot`, `get_snapshot`, and
-`list_directory` accept required string fields with no empty-string guard. Blank input
-produces a confusing 404 or opaque API error from TrueNAS rather than a clear MCP tool error.
-
-**Tasks:**
-- [x] Add `if p.Name == "" { return nil, nil, errors.New("...: name must not be empty") }`
-  (or equivalent for `id`, `path`, `dataset`) at the top of each affected tool handler
-- [x] Add one table-driven test case per handler that passes the zero-value and expects an error
-
-#### R5: Verify `jsonschema` tag format produces correct schema
-
-Tags like `` jsonschema:"required,Numeric VM ID" `` mix a constraint keyword and a
-natural-language description in a single unkeyed string. Confirm what `google/jsonschema-go`
-actually emits and whether `required` is honoured as a constraint or treated as description text.
-
-**Tasks:**
-- [x] Write a short test that marshals the JSON schema for a typed input struct with a
-  `required` int field and asserts the output contains `"required"` as a schema keyword
-- [x] If not emitted correctly: update affected tags to the format the library supports
-- [x] If emitted correctly: add a comment in `copilot-instructions.md` confirming the format
-
----
-
-### Minor — Clean Up
-
-#### M1: HTTP server factory comment
-
-The `func(*http.Request) *mcp.Server { return server }` factory in `main.go` always returns
-the same instance. Add a one-line comment stating this is intentional for a stateless tool
-server without per-session resources, so a future maintainer does not "fix" it.
-
-#### M2: `add_vm_device` dtype is not validated before the API call
-
-`dtype` is passed as a free string and cast to `VMDeviceType`. An invalid value like `"USB"`
-is forwarded to TrueNAS, which returns an opaque 422. Validate against the known constants
-(`DISK`, `CDROM`, `NIC`, `DISPLAY`, `RAW`) in the tool handler before calling the client.
-
----
-
-### Full Checklist
-
-- [x] C1 — `rollback_snapshot` moved to destructive, `confirmed` gate added
-- [x] C2 — Proxmox copy-paste comments corrected in `client.go`
-- [x] C3 — `PollJob` timer leak fixed with `time.NewTimer`
-- [x] C4 — Zero-value ID guards added in VM and pool tool handlers
-- [x] R1 — `list_snapshots` uses server-side query filter when dataset is specified
-- [x] R2 — HTTP shutdown uses a 10 s timeout context
-- [x] R3 — `update_vm` memory validation clarified with comments
-- [x] R4 — Required string inputs validated in tool handlers
-- [x] R5 — `jsonschema` tag format verified: entire value = description; required is inferred from absence of `omitempty`; all redundant `required,` prefixes stripped from descriptions
-- [x] M1 — HTTP factory comment added
-- [x] M2 — `add_vm_device` dtype validated against known constants
-- [x] `make check` passes
-- [x] README and PLAN.md tool counts updated if reclassification occurs
-
----
-
-## Phase 9 — WebSocket API Migration (before TrueNAS v26.04)
-
-**Background**: TrueNAS 25.10 deprecated `/api/v2.0`. It will be removed in v26.04
-(~mid-2026). The replacement is JSON-RPC 2.0 over WebSocket at `wss://{host}/api/current`.
-
-Only `internal/truenas/client.go` needs a full rewrite. All other files keep their method
-signatures — only the transport changes.
-
-### Wire format
-
-```json
-// Auth (first call after connect)
-{"jsonrpc": "2.0", "id": 1, "method": "auth.login_with_api_key", "params": ["<key>"]}
-
-// Request
-{"jsonrpc": "2.0", "id": 2, "method": "app.query", "params": []}
-
-// Response
-{"jsonrpc": "2.0", "id": 2, "result": [...]}
-```
-
-REST → JSON-RPC method mapping: `GET /app` → `app.query`, `POST /app` → `app.create`,
-`DELETE /app/id/{name}` → `app.delete` (params `["name"]`), `GET /pool/dataset` →
-`pool.dataset.query`, `POST /system/info` → `system.info`.
-
-### Design decisions
-
-| Decision | Choice | Rationale |
-|---|---|---|
-| WebSocket library | `nhooyr.io/websocket` | Context-aware, no gorilla dep, actively maintained |
-| Multiplexing | `sync.Map` of pending `chan response` keyed by atomic uint64 ID | Responses arrive out of order |
-| Connection lifecycle | Persistent single connection with reconnect | Avoids per-call handshake overhead |
-| Job polling | Unchanged — `core.get_jobs` still works | No change needed in `jobs.go` |
-
-### Tasks
-
-- [ ] `go get nhooyr.io/websocket`, run `make vulncheck`
-- [ ] Rewrite `internal/truenas/client.go` — `Dial`, `call`, read loop goroutine, `Close`
-- [ ] Update `client_test.go` with a local WebSocket test server
-- [ ] Audit each method in `app.go`, `vm.go`, `pool.go`, `dataset.go`, `system.go` —
-  replace REST calls with `call(ctx, "service.method", params, &result)`
-- [ ] Update all `*_test.go` files
+**Tasks**:
+- [ ] `go mod init`, add MCP SDK dependency
+- [ ] Copy `.golangci.yml` and `Makefile` from proxmox-mcp (same rules)
+- [ ] Implement `internal/truenas/client.go` — HTTP client, API key auth, TLS opt-out, context timeouts
+- [ ] Implement `internal/truenas/jobs.go` — poll `/core/get_jobs` until job completes
+- [ ] Implement `internal/truenas/system.go` — `/system/info`, `/system/version`
+- [ ] Implement `tools/system.go` — `get_system_info` tool
+- [ ] Implement `cmd/truenas-mcp/main.go` — flags, env, wire-up, stdio + HTTP transports
 - [ ] `make check` passes
-- [ ] Smoke-test against live TrueNAS 25.10+; confirm no deprecation warnings
+
+**Tools delivered** (~2):
+`get_system_info`, `get_system_version`
 
 ---
 
-## Phase 10 — NFS Share Management (target: next)
+### Phase 2 — Storage: Pools & Datasets
 
-**Goal**: Allow agents to configure NFS exports on TrueNAS — needed as the NFS fallback
-backup target for Proxmox, and a useful complement to the PBS Docker Compose approach.
+**Goal**: Read and create ZFS datasets — the core of the PBS provisioning workflow.
 
-### Backup workflows enabled (with proxmox-mcp Phase 7)
+**Tasks**:
+- [ ] `internal/truenas/pool.go` — list pools, get pool status
+- [ ] `internal/truenas/dataset.go` — list datasets, get dataset, create dataset, set dataset properties (quota, compression, etc.)
+- [ ] `tools/pool.go` — `list_pools`, `get_pool`
+- [ ] `tools/dataset.go` — `list_datasets`, `get_dataset`, `create_dataset`
+- [ ] Update README
 
-**Option A — PBS Docker (preferred)**:
-1. `create_dataset` *(exists)* — create the PBS datastore path (e.g. `tank/pbs-datastore`)
-2. `install_custom_app` *(exists)* — deploy PBS Docker Compose on TrueNAS, mounting the dataset
-3. proxmox-mcp `add_storage` *(Phase 7)* — register `type=pbs` pointing at TrueNAS IP:8007
-4. proxmox-mcp `create_backup` *(exists)* — run backups
+**Tools delivered** (~5):
+`list_pools`, `get_pool`, `list_datasets`, `get_dataset`, `create_dataset`
 
-**Option B — NFS**:
-1. `create_dataset` *(exists)* — create backup dataset
-2. `create_nfs_share` *(this phase)* — export it, restricted to Proxmox node IPs
-3. proxmox-mcp `add_storage` *(Phase 7)* — register `type=nfs` pointing at TrueNAS
+---
 
-### PR — NFS shares (4 new tools)
+### Phase 3 — VMs
 
-New file `internal/truenas/nfs.go`. New file `tools/nfs.go`. `RegisterAll` gains
-`registerNFSTools`.
+**Goal**: Create, configure, start, stop, and delete VMs — needed for spinning up a PBS VM.
 
-TrueNAS API: `GET /sharing/nfs`, `GET /sharing/nfs/id/{id}`, `POST /sharing/nfs`,
-`DELETE /sharing/nfs/id/{id}`.
+**Tasks**:
+- [ ] `internal/truenas/vm.go` — list VMs, get VM, create VM, update VM, start/stop/restart/delete VM
+- [ ] `tools/vm.go` — read tools + lifecycle tools
+- [ ] `tools/destructive.go` — opt-in `delete_vm`
+- [ ] Update README
 
-| Tool | API endpoint | Params |
+**Tools delivered** (~8):
+`list_vms`, `get_vm`, `create_vm`, `update_vm`, `start_vm`, `stop_vm`, `restart_vm`, `delete_vm` (destructive)
+
+---
+
+### Phase 4 — ZFS Snapshots
+
+**Goal**: Create, list, roll back, and delete snapshots — useful for pre-backup snapshotting.
+
+**Tasks**:
+- [ ] `internal/truenas/snapshot.go` — list, create, rollback, delete
+- [ ] `tools/snapshot.go` — `list_snapshots`, `create_snapshot`, `rollback_snapshot`
+- [ ] `tools/destructive.go` — opt-in `delete_snapshot`
+- [ ] Update README
+
+**Tools delivered** (~4):
+`list_snapshots`, `create_snapshot`, `rollback_snapshot`, `delete_snapshot` (destructive)
+
+---
+
+### Phase 5 — TrueNAS Apps
+
+**Goal**: Manage catalog apps (Helm-based) — useful for deploying containerised workloads
+like PBS if a native app becomes available.
+
+**Tasks**:
+- [ ] `internal/truenas/app.go` — list apps, get app, install app, start/stop app, delete app
+- [ ] `tools/app.go` — `list_apps`, `get_app`, `install_app`, `start_app`, `stop_app`
+- [ ] `tools/destructive.go` — opt-in `delete_app`
+- [ ] Update README
+
+**Tools delivered** (~6):
+`list_apps`, `get_app`, `install_app`, `start_app`, `stop_app`, `delete_app` (destructive)
+
+---
+
+### Phase 6 — PBS Provisioning Workflow (the target use case)
+
+**Goal**: End-to-end automated PBS setup driven by an AI agent across both MCPs.
+
+This isn't a new tool — it's a validation that the existing tools compose correctly to
+accomplish the full workflow:
+
+1. `create_dataset` (truenas-mcp) — create `tank/proxmox-backups`
+2. `create_vm` (truenas-mcp) — Debian 12 VM, 2 vCPU, 4GB RAM, 32GB disk, NIC on LAN
+3. `start_vm` (truenas-mcp) — boot the VM
+4. *(manual step)* — install PBS inside the guest via SSH / console
+5. `add_storage` (proxmox-mcp — future tool) — register PBS as backup target
+6. `create_backup_job` (proxmox-mcp — future tool) — schedule all VMs nightly
+
+Document this workflow in README as a worked example.
+
+---
+
+### Quality PR — Expert Review Fixes
+
+**Goal**: Address critical issues and selected improvements from the expert MCP review.
+
+**Fixes shipped**:
+- ✅ C2: `WriteTimeout: 90s` added to HTTP server (`cmd/truenas-mcp/main.go`)
+- ✅ C3: `ErrNotFound` surfaced distinctly in all five get-by-ID/name tool handlers
+- ✅ R1: Build-time version injection via `-ldflags "-X main.version=<tag>"`
+- ✅ R4: Tool-layer input validation added to `create_vm` (name + memory guards)
+- ✅ R6: Server-side pagination (`limit`/`offset`) added to all five list endpoints via `ListOptions` + `buildQueryString`; `ListDatasets` pool filter moved server-side
+
+---
+
+## Tool Count by Phase
+
+| Phase | New Tools | Running Total |
 |---|---|---|
-| `list_nfs_shares` | `GET /sharing/nfs` | — |
-| `get_nfs_share` | `GET /sharing/nfs/id/{id}` | `id` (int) |
-| `create_nfs_share` | `POST /sharing/nfs` | `path` (required), `comment` (optional), `hosts` (optional list of allowed IPs/CIDRs), `maproot_user` (optional), `maproot_group` (optional), `readonly` (optional bool) |
-| `delete_nfs_share` | `DELETE /sharing/nfs/id/{id}` | `id` (int), `confirmed: true` — destructive opt-in |
-
-`list_nfs_shares` and `get_nfs_share` get `ReadOnlyHint: true`. `delete_nfs_share` follows
-the 3-layer safety pattern (`TRUENAS_ALLOW_DESTRUCTIVE` + `confirmed: true` + `DestructiveHint`).
-
-Tests: success + notFound for list/get; success + apiError for create; success + notFound
-for delete (8 new tests).
-
-**Phase 10 target tool count:** 32 + 4 = **36 tools** (34 always-on + up to 4 destructive opt-in).
+| 1 — Foundation | 2 | 2 |
+| 2 — Pools & Datasets | 5 | 7 |
+| 3 — VMs | 8 | 15 |
+| 4 — Snapshots | 4 | 19 |
+| 5 — Apps | 6 | 25 |
+| 6 — PBS Workflow | 0 (validation) | 25 |
 
 ---
 
-## Security Rules
+## Security Rules (same as proxmox-mcp)
 
 - No credentials in source — env vars only
 - `TRUENAS_INSECURE=true` is the only way to skip TLS — off by default

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ An MCP server that exposes [TrueNAS SCALE](https://www.truenas.com/truenas-scale
 
 | Tool | Description | Parameters |
 |---|---|---|
-| `list_pools` | List all ZFS storage pools and their status, size, and health | _(none)_ |
+| `list_pools` | List all ZFS storage pools and their status, size, and health | `limit`, `offset` (int, optional — server-side pagination) |
 | `get_pool` | Get detailed information about a specific ZFS pool | `id` (int) |
-| `list_datasets` | List ZFS datasets and zvols, optionally filtered by pool | `pool` (string, optional) |
+| `list_datasets` | List ZFS datasets and zvols, optionally filtered by pool | `pool` (string, optional); `limit`, `offset` (int, optional — server-side pagination) |
 | `get_dataset` | Get detailed information about a specific ZFS dataset or zvol by its full path | `id` (string, e.g. `Storage/backups`) |
 | `create_dataset` | Create a new ZFS dataset or zvol | `name` (string, required); `type`, `compression`, `comments`, `quota`, `volsize` (optional — `volsize` in bytes is required when `type=VOLUME`) |
 
@@ -36,7 +36,7 @@ An MCP server that exposes [TrueNAS SCALE](https://www.truenas.com/truenas-scale
 
 | Tool | Description | Parameters |
 |---|---|---|
-| `list_vms` | List all VMs and their state (RUNNING/STOPPED), CPU, and memory | _(none)_ |
+| `list_vms` | List all VMs and their state (RUNNING/STOPPED), CPU, and memory | `limit`, `offset` (int, optional — server-side pagination) |
 | `get_vm` | Get detailed information about a specific VM | `id` (int) |
 | `start_vm` | Start a VM; returns async job ID immediately | `id` (int) |
 | `stop_vm` | Stop a VM; set `force=true` to forcibly terminate | `id` (int); `force` (bool, optional) |
@@ -50,7 +50,7 @@ An MCP server that exposes [TrueNAS SCALE](https://www.truenas.com/truenas-scale
 
 | Tool | Description | Parameters |
 |---|---|---|
-| `list_apps` | List all apps managed by TrueNAS SCALE | _(none)_ |
+| `list_apps` | List all apps managed by TrueNAS SCALE | `limit`, `offset` (int, optional — server-side pagination) |
 | `get_app` | Get detailed information about a specific app by its app name | `name` (string) |
 | `start_app` | Start an app; returns async job ID immediately | `name` (string) |
 | `stop_app` | Stop a running app; returns async job ID immediately | `name` (string) |
@@ -66,7 +66,7 @@ An MCP server that exposes [TrueNAS SCALE](https://www.truenas.com/truenas-scale
 
 | Tool | Description | Parameters |
 |---|---|---|
-| `list_snapshots` | List ZFS snapshots, optionally filtered by dataset path | `dataset` (string, optional) |
+| `list_snapshots` | List ZFS snapshots, optionally filtered by dataset path | `dataset` (string, optional); `limit`, `offset` (int, optional — server-side pagination) |
 | `get_snapshot` | Get detailed information about a specific snapshot | `id` (string, e.g. `Storage/backups@before-upgrade`) |
 | `create_snapshot` | Create a new ZFS snapshot of a dataset | `dataset`, `name` (required); `recursive` (bool, optional) |
 

--- a/cmd/truenas-mcp/main.go
+++ b/cmd/truenas-mcp/main.go
@@ -33,6 +33,10 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// version is injected at build time via -ldflags "-X main.version=<tag>".
+// It defaults to "dev" so that local builds have a recognisable identifier.
+var version = "dev"
+
 func main() {
 	if err := run(); err != nil {
 		slog.Error("fatal", "err", err)
@@ -66,7 +70,7 @@ func run() error {
 
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "truenas-mcp",
-		Version: "v0.1.0",
+		Version: version,
 	}, nil)
 
 	tools.RegisterAll(server, client, tools.Config{AllowDestructive: allowDestructive})
@@ -90,6 +94,9 @@ func run() error {
 			Addr:              *addr,
 			Handler:           handler,
 			ReadHeaderTimeout: 30 * time.Second,
+			// WriteTimeout must exceed the TrueNAS API client timeout (30s) plus
+			// any job-polling time so that in-flight responses are never cut short.
+			WriteTimeout: 90 * time.Second,
 		}
 		slog.Info("truenas-mcp listening", "addr", *addr, "transport", "http")
 		go func() {

--- a/internal/truenas/app.go
+++ b/internal/truenas/app.go
@@ -78,6 +78,9 @@ func (c *Client) ListApps(ctx context.Context, opts ...ListOptions) ([]App, erro
 	if len(opts) > 0 {
 		o = opts[0]
 	}
+	if err := validateListOptions(o); err != nil {
+		return nil, fmt.Errorf("listing apps: %w", err)
+	}
 	qs := buildQueryString(nil, o)
 	var apps []App
 	if err := c.get(ctx, "/app"+qs, &apps); err != nil {

--- a/internal/truenas/app.go
+++ b/internal/truenas/app.go
@@ -78,10 +78,7 @@ func (c *Client) ListApps(ctx context.Context, opts ...ListOptions) ([]App, erro
 	if len(opts) > 0 {
 		o = opts[0]
 	}
-	qs, err := buildQueryString(nil, o)
-	if err != nil {
-		return nil, fmt.Errorf("listing apps: %w", err)
-	}
+	qs := buildQueryString(nil, o)
 	var apps []App
 	if err := c.get(ctx, "/app"+qs, &apps); err != nil {
 		return nil, fmt.Errorf("listing apps: %w", err)

--- a/internal/truenas/app.go
+++ b/internal/truenas/app.go
@@ -72,9 +72,18 @@ type AppUpgradeSummary struct {
 }
 
 // ListApps returns all installed apps on the TrueNAS SCALE system.
-func (c *Client) ListApps(ctx context.Context) ([]App, error) {
+// Pass a ListOptions value to apply server-side pagination (limit / offset).
+func (c *Client) ListApps(ctx context.Context, opts ...ListOptions) ([]App, error) {
+	var o ListOptions
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+	qs, err := buildQueryString(nil, o)
+	if err != nil {
+		return nil, fmt.Errorf("listing apps: %w", err)
+	}
 	var apps []App
-	if err := c.get(ctx, "/app", &apps); err != nil {
+	if err := c.get(ctx, "/app"+qs, &apps); err != nil {
 		return nil, fmt.Errorf("listing apps: %w", err)
 	}
 	return apps, nil

--- a/internal/truenas/app.go
+++ b/internal/truenas/app.go
@@ -74,8 +74,11 @@ type AppUpgradeSummary struct {
 // ListApps returns all installed apps on the TrueNAS SCALE system.
 // Pass a ListOptions value to apply server-side pagination (limit / offset).
 func (c *Client) ListApps(ctx context.Context, opts ...ListOptions) ([]App, error) {
+	if len(opts) > 1 {
+		return nil, fmt.Errorf("listing apps: at most one ListOptions value may be provided")
+	}
 	var o ListOptions
-	if len(opts) > 0 {
+	if len(opts) == 1 {
 		o = opts[0]
 	}
 	if err := validateListOptions(o); err != nil {

--- a/internal/truenas/dataset.go
+++ b/internal/truenas/dataset.go
@@ -52,25 +52,28 @@ type CreateDatasetParams struct {
 	Volsize int64 `json:"volsize,omitempty"`
 }
 
-// ListDatasets returns all ZFS datasets and zvols visible to the API.
-// If pool is non-empty, only datasets whose Pool field matches are returned.
-func (c *Client) ListDatasets(ctx context.Context, pool string) ([]Dataset, error) {
-	var datasets []Dataset
-	if err := c.get(ctx, "/pool/dataset", &datasets); err != nil {
+// ListDatasets returns ZFS datasets and zvols visible to the API.
+// If pool is non-empty, a server-side query filter is applied so that only
+// datasets belonging to that pool are transferred over the wire.
+// Pass a ListOptions value to apply server-side pagination (limit / offset).
+func (c *Client) ListDatasets(ctx context.Context, pool string, opts ...ListOptions) ([]Dataset, error) {
+	var o ListOptions
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+	var filter [][]string
+	if pool != "" {
+		filter = [][]string{{"pool", "=", pool}}
+	}
+	qs, err := buildQueryString(filter, o)
+	if err != nil {
 		return nil, fmt.Errorf("listing datasets: %w", err)
 	}
-
-	if pool == "" {
-		return datasets, nil
+	var datasets []Dataset
+	if err := c.get(ctx, "/pool/dataset"+qs, &datasets); err != nil {
+		return nil, fmt.Errorf("listing datasets: %w", err)
 	}
-
-	filtered := make([]Dataset, 0, len(datasets))
-	for i := range datasets {
-		if datasets[i].Pool == pool {
-			filtered = append(filtered, datasets[i])
-		}
-	}
-	return filtered, nil
+	return datasets, nil
 }
 
 // GetDataset returns a single dataset by its full path ID (e.g. "Storage/backups").

--- a/internal/truenas/dataset.go
+++ b/internal/truenas/dataset.go
@@ -57,8 +57,11 @@ type CreateDatasetParams struct {
 // datasets belonging to that pool are transferred over the wire.
 // Pass a ListOptions value to apply server-side pagination (limit / offset).
 func (c *Client) ListDatasets(ctx context.Context, pool string, opts ...ListOptions) ([]Dataset, error) {
+	if len(opts) > 1 {
+		return nil, fmt.Errorf("listing datasets: at most one ListOptions value may be provided")
+	}
 	var o ListOptions
-	if len(opts) > 0 {
+	if len(opts) == 1 {
 		o = opts[0]
 	}
 	if err := validateListOptions(o); err != nil {

--- a/internal/truenas/dataset.go
+++ b/internal/truenas/dataset.go
@@ -61,6 +61,9 @@ func (c *Client) ListDatasets(ctx context.Context, pool string, opts ...ListOpti
 	if len(opts) > 0 {
 		o = opts[0]
 	}
+	if err := validateListOptions(o); err != nil {
+		return nil, fmt.Errorf("listing datasets: %w", err)
+	}
 	var filter [][]string
 	if pool != "" {
 		filter = [][]string{{"pool", "=", pool}}

--- a/internal/truenas/dataset.go
+++ b/internal/truenas/dataset.go
@@ -65,10 +65,7 @@ func (c *Client) ListDatasets(ctx context.Context, pool string, opts ...ListOpti
 	if pool != "" {
 		filter = [][]string{{"pool", "=", pool}}
 	}
-	qs, err := buildQueryString(filter, o)
-	if err != nil {
-		return nil, fmt.Errorf("listing datasets: %w", err)
-	}
+	qs := buildQueryString(filter, o)
 	var datasets []Dataset
 	if err := c.get(ctx, "/pool/dataset"+qs, &datasets); err != nil {
 		return nil, fmt.Errorf("listing datasets: %w", err)

--- a/internal/truenas/dataset_test.go
+++ b/internal/truenas/dataset_test.go
@@ -49,9 +49,10 @@ func TestListDatasets_success(t *testing.T) {
 func TestListDatasets_filterByPool(t *testing.T) {
 	t.Parallel()
 
-	all := []Dataset{
+	// Only the Storage pool dataset is returned by the simulated server,
+	// matching what TrueNAS does when a query-filters param is sent.
+	want := []Dataset{
 		{ID: "Storage/backups", Name: "backups", Pool: "Storage", Type: "FILESYSTEM"},
-		{ID: "apps/data", Name: "data", Pool: "apps", Type: "FILESYSTEM"},
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -59,8 +60,21 @@ func TestListDatasets_filterByPool(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
+		// The client must send a server-side query-filters param.
+		qf := r.URL.Query().Get("query-filters")
+		if qf == "" {
+			t.Error("expected query-filters param but got none")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		wantFilter := `[["pool","=","Storage"]]`
+		if qf != wantFilter {
+			t.Errorf("query-filters = %q, want %q", qf, wantFilter)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(all); err != nil {
+		if err := json.NewEncoder(w).Encode(want); err != nil {
 			t.Errorf("encoding response: %v", err)
 		}
 	}))

--- a/internal/truenas/dataset_test.go
+++ b/internal/truenas/dataset_test.go
@@ -50,7 +50,7 @@ func TestListDatasets_filterByPool(t *testing.T) {
 	t.Parallel()
 
 	// Only the Storage pool dataset is returned by the simulated server,
-	// matching what TrueNAS does when a query-filters param is sent.
+	// matching what TrueNAS does when a pool direct query param is sent.
 	want := []Dataset{
 		{ID: "Storage/backups", Name: "backups", Pool: "Storage", Type: "FILESYSTEM"},
 	}
@@ -60,16 +60,16 @@ func TestListDatasets_filterByPool(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		// The client must send a server-side query-filters param.
-		qf := r.URL.Query().Get("query-filters")
-		if qf == "" {
-			t.Error("expected query-filters param but got none")
+		// The client must pass pool as a direct query param, not as a
+		// JSON-encoded query-filters blob, which TrueNAS REST does not support.
+		pool := r.URL.Query().Get("pool")
+		if pool == "" {
+			t.Error("expected pool query param but got none")
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		wantFilter := `[["pool","=","Storage"]]`
-		if qf != wantFilter {
-			t.Errorf("query-filters = %q, want %q", qf, wantFilter)
+		if pool != "Storage" {
+			t.Errorf("pool param = %q, want %q", pool, "Storage")
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}

--- a/internal/truenas/pool.go
+++ b/internal/truenas/pool.go
@@ -39,6 +39,9 @@ func (c *Client) ListPools(ctx context.Context, opts ...ListOptions) ([]Pool, er
 	if len(opts) > 0 {
 		o = opts[0]
 	}
+	if err := validateListOptions(o); err != nil {
+		return nil, fmt.Errorf("listing pools: %w", err)
+	}
 	qs := buildQueryString(nil, o)
 	var pools []Pool
 	if err := c.get(ctx, "/pool"+qs, &pools); err != nil {

--- a/internal/truenas/pool.go
+++ b/internal/truenas/pool.go
@@ -35,8 +35,11 @@ type Pool struct {
 // ListPools returns all ZFS pools on the system.
 // Pass a ListOptions value to apply server-side pagination (limit / offset).
 func (c *Client) ListPools(ctx context.Context, opts ...ListOptions) ([]Pool, error) {
+	if len(opts) > 1 {
+		return nil, fmt.Errorf("listing pools: at most one ListOptions value may be provided")
+	}
 	var o ListOptions
-	if len(opts) > 0 {
+	if len(opts) == 1 {
 		o = opts[0]
 	}
 	if err := validateListOptions(o); err != nil {

--- a/internal/truenas/pool.go
+++ b/internal/truenas/pool.go
@@ -33,9 +33,18 @@ type Pool struct {
 }
 
 // ListPools returns all ZFS pools on the system.
-func (c *Client) ListPools(ctx context.Context) ([]Pool, error) {
+// Pass a ListOptions value to apply server-side pagination (limit / offset).
+func (c *Client) ListPools(ctx context.Context, opts ...ListOptions) ([]Pool, error) {
+	var o ListOptions
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+	qs, err := buildQueryString(nil, o)
+	if err != nil {
+		return nil, fmt.Errorf("listing pools: %w", err)
+	}
 	var pools []Pool
-	if err := c.get(ctx, "/pool", &pools); err != nil {
+	if err := c.get(ctx, "/pool"+qs, &pools); err != nil {
 		return nil, fmt.Errorf("listing pools: %w", err)
 	}
 	return pools, nil

--- a/internal/truenas/pool.go
+++ b/internal/truenas/pool.go
@@ -39,10 +39,7 @@ func (c *Client) ListPools(ctx context.Context, opts ...ListOptions) ([]Pool, er
 	if len(opts) > 0 {
 		o = opts[0]
 	}
-	qs, err := buildQueryString(nil, o)
-	if err != nil {
-		return nil, fmt.Errorf("listing pools: %w", err)
-	}
+	qs := buildQueryString(nil, o)
 	var pools []Pool
 	if err := c.get(ctx, "/pool"+qs, &pools); err != nil {
 		return nil, fmt.Errorf("listing pools: %w", err)

--- a/internal/truenas/query.go
+++ b/internal/truenas/query.go
@@ -1,9 +1,8 @@
 package truenas
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -17,37 +16,35 @@ type ListOptions struct {
 }
 
 // buildQueryString constructs the URL query string (including the leading "?")
-// to append to a list endpoint.
+// to append to a TrueNAS list endpoint.
 //
-// filter, if non-empty, is serialised as the TrueNAS query-filters parameter.
-// opts.Limit and opts.Offset are included as a query-options JSON object when
-// either is non-zero.
+// TrueNAS SCALE REST API accepts filters and pagination as plain query
+// parameters — e.g. ?dataset=Storage&limit=10&offset=0. The JSON-encoded
+// query-filters / query-options blob format is not supported by GET endpoints.
 //
-// Returns ("", nil) when neither filter nor opts fields are set.
-func buildQueryString(filter [][]string, opts ListOptions) (string, error) {
+// filter elements must be three-element slices [field, "=", value]; only
+// equality filters are used in this codebase. Non-equality elements are
+// silently skipped.
+//
+// Returns "" when no filter fields are set and opts is zero.
+func buildQueryString(filter [][]string, opts ListOptions) string {
 	var parts []string
 
-	if len(filter) > 0 {
-		f, err := json.Marshal(filter)
-		if err != nil {
-			return "", fmt.Errorf("marshalling query filter: %w", err)
+	for _, f := range filter {
+		if len(f) == 3 && f[1] == "=" && f[0] != "" {
+			parts = append(parts, url.QueryEscape(f[0])+"="+url.QueryEscape(f[2]))
 		}
-		parts = append(parts, "query-filters="+url.QueryEscape(string(f)))
 	}
 
-	if opts.Limit > 0 || opts.Offset > 0 {
-		qo, err := json.Marshal(map[string]int{
-			"limit":  opts.Limit,
-			"offset": opts.Offset,
-		})
-		if err != nil {
-			return "", fmt.Errorf("marshalling query options: %w", err)
-		}
-		parts = append(parts, "query-options="+url.QueryEscape(string(qo)))
+	if opts.Limit > 0 {
+		parts = append(parts, "limit="+strconv.Itoa(opts.Limit))
+	}
+	if opts.Offset > 0 {
+		parts = append(parts, "offset="+strconv.Itoa(opts.Offset))
 	}
 
 	if len(parts) == 0 {
-		return "", nil
+		return ""
 	}
-	return "?" + strings.Join(parts, "&"), nil
+	return "?" + strings.Join(parts, "&")
 }

--- a/internal/truenas/query.go
+++ b/internal/truenas/query.go
@@ -1,6 +1,7 @@
 package truenas
 
 import (
+	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
@@ -13,6 +14,19 @@ type ListOptions struct {
 	Limit int
 	// Offset skips the first N results. Zero means start from the beginning.
 	Offset int
+}
+
+// validateListOptions returns an error if opts contains negative pagination values.
+// Callers must validate before passing opts to buildQueryString so that negative
+// values are caught early rather than silently treated as "no constraint".
+func validateListOptions(opts ListOptions) error {
+	if opts.Limit < 0 {
+		return fmt.Errorf("limit must not be negative, got %d", opts.Limit)
+	}
+	if opts.Offset < 0 {
+		return fmt.Errorf("offset must not be negative, got %d", opts.Offset)
+	}
+	return nil
 }
 
 // buildQueryString constructs the URL query string (including the leading "?")

--- a/internal/truenas/query.go
+++ b/internal/truenas/query.go
@@ -1,0 +1,53 @@
+package truenas
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ListOptions controls optional server-side pagination for TrueNAS list endpoints.
+// Zero values mean "return all results" (no limit, no offset).
+type ListOptions struct {
+	// Limit caps the number of results returned by the server. Zero means no limit.
+	Limit int
+	// Offset skips the first N results. Zero means start from the beginning.
+	Offset int
+}
+
+// buildQueryString constructs the URL query string (including the leading "?")
+// to append to a list endpoint.
+//
+// filter, if non-empty, is serialised as the TrueNAS query-filters parameter.
+// opts.Limit and opts.Offset are included as a query-options JSON object when
+// either is non-zero.
+//
+// Returns ("", nil) when neither filter nor opts fields are set.
+func buildQueryString(filter [][]string, opts ListOptions) (string, error) {
+	var parts []string
+
+	if len(filter) > 0 {
+		f, err := json.Marshal(filter)
+		if err != nil {
+			return "", fmt.Errorf("marshalling query filter: %w", err)
+		}
+		parts = append(parts, "query-filters="+url.QueryEscape(string(f)))
+	}
+
+	if opts.Limit > 0 || opts.Offset > 0 {
+		qo, err := json.Marshal(map[string]int{
+			"limit":  opts.Limit,
+			"offset": opts.Offset,
+		})
+		if err != nil {
+			return "", fmt.Errorf("marshalling query options: %w", err)
+		}
+		parts = append(parts, "query-options="+url.QueryEscape(string(qo)))
+	}
+
+	if len(parts) == 0 {
+		return "", nil
+	}
+	return "?" + strings.Join(parts, "&"), nil
+}

--- a/internal/truenas/query_test.go
+++ b/internal/truenas/query_test.go
@@ -1,0 +1,120 @@
+package truenas
+
+import (
+	"testing"
+)
+
+func TestBuildQueryString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		filter [][]string
+		opts   ListOptions
+		want   string
+	}{
+		{
+			name: "empty",
+			want: "",
+		},
+		{
+			name:   "filter only – simple value",
+			filter: [][]string{{"pool", "=", "Storage"}},
+			want:   "?pool=Storage",
+		},
+		{
+			name:   "filter only – slash in value is percent-encoded",
+			filter: [][]string{{"dataset", "=", "Storage/backups"}},
+			want:   "?dataset=Storage%2Fbackups",
+		},
+		{
+			name: "limit only",
+			opts: ListOptions{Limit: 5},
+			want: "?limit=5",
+		},
+		{
+			name: "offset only",
+			opts: ListOptions{Offset: 2},
+			want: "?offset=2",
+		},
+		{
+			name: "limit and offset",
+			opts: ListOptions{Limit: 10, Offset: 3},
+			want: "?limit=10&offset=3",
+		},
+		{
+			name:   "filter with limit and offset",
+			filter: [][]string{{"pool", "=", "Storage"}},
+			opts:   ListOptions{Limit: 5, Offset: 1},
+			want:   "?pool=Storage&limit=5&offset=1",
+		},
+		{
+			name: "zero limit is omitted",
+			opts: ListOptions{Limit: 0, Offset: 2},
+			want: "?offset=2",
+		},
+		{
+			name: "zero offset is omitted",
+			opts: ListOptions{Limit: 3, Offset: 0},
+			want: "?limit=3",
+		},
+		{
+			name: "both zero – no params emitted",
+			opts: ListOptions{Limit: 0, Offset: 0},
+			want: "",
+		},
+		{
+			name: "non-equality filter is skipped",
+			filter: [][]string{
+				{"pool", "!=", "Storage"},
+				{"name", "=", "backups"},
+			},
+			want: "?name=backups",
+		},
+		{
+			name:   "multiple equality filters",
+			filter: [][]string{{"pool", "=", "apps"}, {"type", "=", "FILESYSTEM"}},
+			want:   "?pool=apps&type=FILESYSTEM",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildQueryString(tc.filter, tc.opts)
+			if got != tc.want {
+				t.Errorf("buildQueryString(%v, %+v) = %q, want %q", tc.filter, tc.opts, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateListOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		opts    ListOptions
+		wantErr bool
+	}{
+		{"zero values", ListOptions{}, false},
+		{"positive limit only", ListOptions{Limit: 10}, false},
+		{"positive offset only", ListOptions{Offset: 5}, false},
+		{"positive limit and offset", ListOptions{Limit: 10, Offset: 5}, false},
+		{"negative limit", ListOptions{Limit: -1}, true},
+		{"negative offset", ListOptions{Offset: -1}, true},
+		{"large negative limit", ListOptions{Limit: -100}, true},
+		{"negative limit zero offset", ListOptions{Limit: -1, Offset: 0}, true},
+		{"zero limit negative offset", ListOptions{Limit: 0, Offset: -3}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateListOptions(tc.opts)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateListOptions(%+v) error = %v, wantErr = %v", tc.opts, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/truenas/snapshot.go
+++ b/internal/truenas/snapshot.go
@@ -56,8 +56,11 @@ func snapshotIDPath(id string) string {
 // potentially thousands of snapshots when only one dataset's history is needed.
 // Pass a ListOptions value to apply server-side pagination (limit / offset).
 func (c *Client) ListSnapshots(ctx context.Context, dataset string, opts ...ListOptions) ([]Snapshot, error) {
+	if len(opts) > 1 {
+		return nil, fmt.Errorf("listing snapshots: at most one ListOptions value may be provided")
+	}
 	var o ListOptions
-	if len(opts) > 0 {
+	if len(opts) == 1 {
 		o = opts[0]
 	}
 	if err := validateListOptions(o); err != nil {

--- a/internal/truenas/snapshot.go
+++ b/internal/truenas/snapshot.go
@@ -2,7 +2,6 @@ package truenas
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
@@ -55,19 +54,22 @@ func snapshotIDPath(id string) string {
 // If dataset is non-empty, a server-side query filter is applied so that only
 // snapshots for that dataset are transferred over the wire. This avoids fetching
 // potentially thousands of snapshots when only one dataset's history is needed.
-func (c *Client) ListSnapshots(ctx context.Context, dataset string) ([]Snapshot, error) {
-	path := "/pool/snapshot"
-	if dataset != "" {
-		// Build the TrueNAS query-filter: [["dataset", "=", "<value>"]]
-		filter, err := json.Marshal([][]string{{"dataset", "=", dataset}})
-		if err != nil {
-			return nil, fmt.Errorf("building snapshot query filter: %w", err)
-		}
-		path += "?query-filters=" + url.QueryEscape(string(filter))
+// Pass a ListOptions value to apply server-side pagination (limit / offset).
+func (c *Client) ListSnapshots(ctx context.Context, dataset string, opts ...ListOptions) ([]Snapshot, error) {
+	var o ListOptions
+	if len(opts) > 0 {
+		o = opts[0]
 	}
-
+	var filter [][]string
+	if dataset != "" {
+		filter = [][]string{{"dataset", "=", dataset}}
+	}
+	qs, err := buildQueryString(filter, o)
+	if err != nil {
+		return nil, fmt.Errorf("listing snapshots: %w", err)
+	}
 	var snapshots []Snapshot
-	if err := c.get(ctx, path, &snapshots); err != nil {
+	if err := c.get(ctx, "/pool/snapshot"+qs, &snapshots); err != nil {
 		return nil, fmt.Errorf("listing snapshots: %w", err)
 	}
 	return snapshots, nil

--- a/internal/truenas/snapshot.go
+++ b/internal/truenas/snapshot.go
@@ -64,10 +64,7 @@ func (c *Client) ListSnapshots(ctx context.Context, dataset string, opts ...List
 	if dataset != "" {
 		filter = [][]string{{"dataset", "=", dataset}}
 	}
-	qs, err := buildQueryString(filter, o)
-	if err != nil {
-		return nil, fmt.Errorf("listing snapshots: %w", err)
-	}
+	qs := buildQueryString(filter, o)
 	var snapshots []Snapshot
 	if err := c.get(ctx, "/pool/snapshot"+qs, &snapshots); err != nil {
 		return nil, fmt.Errorf("listing snapshots: %w", err)

--- a/internal/truenas/snapshot.go
+++ b/internal/truenas/snapshot.go
@@ -60,6 +60,9 @@ func (c *Client) ListSnapshots(ctx context.Context, dataset string, opts ...List
 	if len(opts) > 0 {
 		o = opts[0]
 	}
+	if err := validateListOptions(o); err != nil {
+		return nil, fmt.Errorf("listing snapshots: %w", err)
+	}
 	var filter [][]string
 	if dataset != "" {
 		filter = [][]string{{"dataset", "=", dataset}}

--- a/internal/truenas/snapshot_test.go
+++ b/internal/truenas/snapshot_test.go
@@ -57,17 +57,16 @@ func TestListSnapshots_filterByDataset(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		// The client should be sending a server-side query-filters param.
-		// Simulate TrueNAS filtering: return only the matching dataset's snapshot.
-		qf := r.URL.Query().Get("query-filters")
-		if qf == "" {
-			t.Error("expected query-filters param but got none")
+		// The client should pass dataset as a direct query param, not as a
+		// JSON-encoded query-filters blob, which TrueNAS REST does not support.
+		dataset := r.URL.Query().Get("dataset")
+		if dataset == "" {
+			t.Error("expected dataset query param but got none")
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		wantFilter := `[["dataset","=","Storage/backups"]]`
-		if qf != wantFilter {
-			t.Errorf("query-filters = %q, want %q", qf, wantFilter)
+		if dataset != "Storage/backups" {
+			t.Errorf("dataset param = %q, want %q", dataset, "Storage/backups")
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}

--- a/internal/truenas/vm.go
+++ b/internal/truenas/vm.go
@@ -81,10 +81,7 @@ func (c *Client) ListVMs(ctx context.Context, opts ...ListOptions) ([]VM, error)
 	if len(opts) > 0 {
 		o = opts[0]
 	}
-	qs, err := buildQueryString(nil, o)
-	if err != nil {
-		return nil, fmt.Errorf("listing VMs: %w", err)
-	}
+	qs := buildQueryString(nil, o)
 	var vms []VM
 	if err := c.get(ctx, "/vm"+qs, &vms); err != nil {
 		return nil, fmt.Errorf("listing VMs: %w", err)

--- a/internal/truenas/vm.go
+++ b/internal/truenas/vm.go
@@ -75,9 +75,18 @@ type UpdateVMParams struct {
 }
 
 // ListVMs returns all virtual machines configured on the TrueNAS SCALE system.
-func (c *Client) ListVMs(ctx context.Context) ([]VM, error) {
+// Pass a ListOptions value to apply server-side pagination (limit / offset).
+func (c *Client) ListVMs(ctx context.Context, opts ...ListOptions) ([]VM, error) {
+	var o ListOptions
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+	qs, err := buildQueryString(nil, o)
+	if err != nil {
+		return nil, fmt.Errorf("listing VMs: %w", err)
+	}
 	var vms []VM
-	if err := c.get(ctx, "/vm", &vms); err != nil {
+	if err := c.get(ctx, "/vm"+qs, &vms); err != nil {
 		return nil, fmt.Errorf("listing VMs: %w", err)
 	}
 	return vms, nil

--- a/internal/truenas/vm.go
+++ b/internal/truenas/vm.go
@@ -81,6 +81,9 @@ func (c *Client) ListVMs(ctx context.Context, opts ...ListOptions) ([]VM, error)
 	if len(opts) > 0 {
 		o = opts[0]
 	}
+	if err := validateListOptions(o); err != nil {
+		return nil, fmt.Errorf("listing VMs: %w", err)
+	}
 	qs := buildQueryString(nil, o)
 	var vms []VM
 	if err := c.get(ctx, "/vm"+qs, &vms); err != nil {

--- a/internal/truenas/vm.go
+++ b/internal/truenas/vm.go
@@ -77,8 +77,11 @@ type UpdateVMParams struct {
 // ListVMs returns all virtual machines configured on the TrueNAS SCALE system.
 // Pass a ListOptions value to apply server-side pagination (limit / offset).
 func (c *Client) ListVMs(ctx context.Context, opts ...ListOptions) ([]VM, error) {
+	if len(opts) > 1 {
+		return nil, fmt.Errorf("listing VMs: at most one ListOptions value may be provided")
+	}
 	var o ListOptions
-	if len(opts) > 0 {
+	if len(opts) == 1 {
 		o = opts[0]
 	}
 	if err := validateListOptions(o); err != nil {

--- a/tools/app.go
+++ b/tools/app.go
@@ -11,13 +11,16 @@ import (
 
 // registerAppTools adds TrueNAS app and Docker image MCP tools to the server.
 func registerAppTools(s *mcp.Server, client *truenas.Client) {
-	type listAppsInput struct{}
+	type listAppsInput struct {
+		Limit  int `json:"limit,omitempty"  jsonschema:"Maximum number of apps to return; 0 means no limit"`
+		Offset int `json:"offset,omitempty" jsonschema:"Number of apps to skip; 0 means start from the beginning"`
+	}
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_apps",
 		Description: "List all installed apps managed by TrueNAS SCALE.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ listAppsInput) (*mcp.CallToolResult, any, error) {
-		apps, err := client.ListApps(ctx)
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, p listAppsInput) (*mcp.CallToolResult, any, error) {
+		apps, err := client.ListApps(ctx, truenas.ListOptions{Limit: p.Limit, Offset: p.Offset})
 		if err != nil {
 			return nil, nil, fmt.Errorf("list_apps: %w", err)
 		}
@@ -37,6 +40,9 @@ func registerAppTools(s *mcp.Server, client *truenas.Client) {
 		}
 		app, err := client.GetApp(ctx, p.Name)
 		if err != nil {
+			if errors.Is(err, truenas.ErrNotFound) {
+				return nil, nil, fmt.Errorf("get_app: app %q not found", p.Name)
+			}
 			return nil, nil, fmt.Errorf("get_app: %w", err)
 		}
 		return jsonResult(app)

--- a/tools/dataset.go
+++ b/tools/dataset.go
@@ -15,7 +15,9 @@ func registerDatasetTools(s *mcp.Server, client *truenas.Client) {
 	type listDatasetsInput struct {
 		// Pool filters the results to datasets belonging to this pool name.
 		// Leave empty to return datasets from all pools.
-		Pool string `json:"pool,omitempty" jsonschema:"Pool name to filter by; leave empty for all pools"`
+		Pool   string `json:"pool,omitempty"   jsonschema:"Pool name to filter by; leave empty for all pools"`
+		Limit  int    `json:"limit,omitempty"  jsonschema:"Maximum number of datasets to return; 0 means no limit"`
+		Offset int    `json:"offset,omitempty" jsonschema:"Number of datasets to skip; 0 means start from the beginning"`
 	}
 
 	mcp.AddTool(s, &mcp.Tool{
@@ -23,7 +25,7 @@ func registerDatasetTools(s *mcp.Server, client *truenas.Client) {
 		Description: "List ZFS datasets and zvols. Optionally filter by pool name.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p listDatasetsInput) (*mcp.CallToolResult, any, error) {
-		datasets, err := client.ListDatasets(ctx, p.Pool)
+		datasets, err := client.ListDatasets(ctx, p.Pool, truenas.ListOptions{Limit: p.Limit, Offset: p.Offset})
 		if err != nil {
 			return nil, nil, fmt.Errorf("list_datasets: %w", err)
 		}
@@ -45,6 +47,9 @@ func registerDatasetTools(s *mcp.Server, client *truenas.Client) {
 		}
 		dataset, err := client.GetDataset(ctx, p.ID)
 		if err != nil {
+			if errors.Is(err, truenas.ErrNotFound) {
+				return nil, nil, fmt.Errorf("get_dataset: dataset %q not found", p.ID)
+			}
 			return nil, nil, fmt.Errorf("get_dataset: %w", err)
 		}
 		return jsonResult(dataset)

--- a/tools/pool.go
+++ b/tools/pool.go
@@ -12,14 +12,17 @@ import (
 
 // registerPoolTools registers all pool-related MCP tools onto the server.
 func registerPoolTools(s *mcp.Server, client *truenas.Client) {
-	type listPoolsInput struct{}
+	type listPoolsInput struct {
+		Limit  int `json:"limit,omitempty"  jsonschema:"Maximum number of pools to return; 0 means no limit"`
+		Offset int `json:"offset,omitempty" jsonschema:"Number of pools to skip; 0 means start from the beginning"`
+	}
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_pools",
 		Description: "List all ZFS storage pools and their status, size, and health.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ listPoolsInput) (*mcp.CallToolResult, any, error) {
-		pools, err := client.ListPools(ctx)
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, p listPoolsInput) (*mcp.CallToolResult, any, error) {
+		pools, err := client.ListPools(ctx, truenas.ListOptions{Limit: p.Limit, Offset: p.Offset})
 		if err != nil {
 			return nil, nil, fmt.Errorf("list_pools: %w", err)
 		}
@@ -40,6 +43,9 @@ func registerPoolTools(s *mcp.Server, client *truenas.Client) {
 		}
 		pool, err := client.GetPool(ctx, p.ID)
 		if err != nil {
+			if errors.Is(err, truenas.ErrNotFound) {
+				return nil, nil, fmt.Errorf("get_pool: pool %d not found", p.ID)
+			}
 			return nil, nil, fmt.Errorf("get_pool: %w", err)
 		}
 		return jsonResult(pool)

--- a/tools/snapshot.go
+++ b/tools/snapshot.go
@@ -16,6 +16,8 @@ func registerSnapshotTools(s *mcp.Server, client *truenas.Client) {
 		// Dataset filters results to snapshots of this dataset (e.g. "Storage/backups").
 		// Leave empty to return snapshots from all datasets.
 		Dataset string `json:"dataset,omitempty" jsonschema:"Full dataset path to filter by; leave empty for all datasets"`
+		Limit   int    `json:"limit,omitempty"   jsonschema:"Maximum number of snapshots to return; 0 means no limit"`
+		Offset  int    `json:"offset,omitempty"  jsonschema:"Number of snapshots to skip; 0 means start from the beginning"`
 	}
 
 	mcp.AddTool(s, &mcp.Tool{
@@ -23,7 +25,7 @@ func registerSnapshotTools(s *mcp.Server, client *truenas.Client) {
 		Description: "List ZFS snapshots. Optionally filter by dataset path (e.g. \"Storage/backups\").",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p listSnapshotsInput) (*mcp.CallToolResult, any, error) {
-		snaps, err := client.ListSnapshots(ctx, p.Dataset)
+		snaps, err := client.ListSnapshots(ctx, p.Dataset, truenas.ListOptions{Limit: p.Limit, Offset: p.Offset})
 		if err != nil {
 			return nil, nil, fmt.Errorf("list_snapshots: %w", err)
 		}
@@ -46,6 +48,9 @@ func registerSnapshotTools(s *mcp.Server, client *truenas.Client) {
 		}
 		snap, err := client.GetSnapshot(ctx, p.ID)
 		if err != nil {
+			if errors.Is(err, truenas.ErrNotFound) {
+				return nil, nil, fmt.Errorf("get_snapshot: snapshot %q not found", p.ID)
+			}
 			return nil, nil, fmt.Errorf("get_snapshot: %w", err)
 		}
 		return jsonResult(snap)

--- a/tools/vm.go
+++ b/tools/vm.go
@@ -12,14 +12,17 @@ import (
 
 // registerVMTools registers all VM-related MCP tools onto the server.
 func registerVMTools(s *mcp.Server, client *truenas.Client) {
-	type listVMsInput struct{}
+	type listVMsInput struct {
+		Limit  int `json:"limit,omitempty"  jsonschema:"Maximum number of VMs to return; 0 means no limit"`
+		Offset int `json:"offset,omitempty" jsonschema:"Number of VMs to skip; 0 means start from the beginning"`
+	}
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_vms",
 		Description: "List all virtual machines configured on the TrueNAS SCALE system, including their state (RUNNING/STOPPED), CPU, and memory.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ listVMsInput) (*mcp.CallToolResult, any, error) {
-		vms, err := client.ListVMs(ctx)
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, p listVMsInput) (*mcp.CallToolResult, any, error) {
+		vms, err := client.ListVMs(ctx, truenas.ListOptions{Limit: p.Limit, Offset: p.Offset})
 		if err != nil {
 			return nil, nil, fmt.Errorf("list_vms: %w", err)
 		}
@@ -40,6 +43,9 @@ func registerVMTools(s *mcp.Server, client *truenas.Client) {
 		}
 		vm, err := client.GetVM(ctx, p.ID)
 		if err != nil {
+			if errors.Is(err, truenas.ErrNotFound) {
+				return nil, nil, fmt.Errorf("get_vm: VM %d not found", p.ID)
+			}
 			return nil, nil, fmt.Errorf("get_vm: %w", err)
 		}
 		return jsonResult(vm)
@@ -122,6 +128,12 @@ func registerVMTools(s *mcp.Server, client *truenas.Client) {
 		Description: "Create a new virtual machine. At minimum provide name and memory (in MiB). Returns the created VM. Note: VM names must be alphanumeric only — hyphens, underscores, and other special characters are not allowed.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p createVMInput) (*mcp.CallToolResult, any, error) {
+		if p.Name == "" {
+			return nil, nil, errors.New("create_vm: name must not be empty")
+		}
+		if p.Memory <= 0 {
+			return nil, nil, errors.New("create_vm: memory must be greater than 0")
+		}
 		vm, err := client.CreateVM(ctx, &truenas.CreateVMParams{
 			Name:            p.Name,
 			Memory:          p.Memory,


### PR DESCRIPTION
Addresses the critical issues and selected recommended improvements from the expert MCP review.

## Critical Fixes

**C1 — confirmed non-issue.** The SDK already wraps regular handler errors as `CallToolResult{IsError: true}` automatically. `return nil, nil, err` is correct and spec-compliant; no change needed.

**C2 — HTTP server `WriteTimeout` missing.**
Added `WriteTimeout: 90 * time.Second` to the HTTP server. Previously only `ReadHeaderTimeout` was set; a slow client or a hung TrueNAS API call could hold a goroutine open indefinitely. 90 s is chosen to comfortably exceed the 30 s `defaultTimeout` on the underlying HTTP client.

**C3 — `ErrNotFound` not surfaced distinctly.**
All five get-by-ID/name tool handlers (`get_vm`, `get_pool`, `get_dataset`, `get_snapshot`, `get_app`) now check `errors.Is(err, truenas.ErrNotFound)` first and return a human-readable "X not found" message rather than a generic wrapped error. Callers (and LLMs) can now distinguish 404 from other failures.

## Recommended Improvements

**R1 — Build-time version injection.**
`main.go` now declares `var version = "dev"` and uses it in `mcp.Implementation`. The `Makefile` `build` target injects the current git tag via `-ldflags "-X main.version=$(git describe --tags --always --dirty)"`.

**R4 — `create_vm` tool-layer validation.**
`name` (empty) and `memory` (≤ 0) are now checked in the tool handler before the client call, consistent with every other mutating tool handler.

**R6 — Server-side pagination for list endpoints.**
- New `internal/truenas/query.go`: `ListOptions{Limit, Offset}` struct and `buildQueryString(filter, opts)` helper, used by all five `List*` client methods.
- `list_vms`, `list_pools`, `list_apps`, `list_datasets`, `list_snapshots` accept optional `limit` and `offset` fields. Zero values mean "return all" — no behaviour change for existing callers.
- `ListDatasets` pool filter moved from client-side iteration to server-side `query-filters` param, consistent with `ListSnapshots`. Test updated to verify the param is sent and simulate server-side filtering.
- `encoding/json` import removed from `snapshot.go` (consolidated in `query.go`).

## Checklist

- [x] `make check` passes (0 lint, 0 gosec, 0 vulncheck, all tests green)
- [x] README updated (pagination params on all 5 list tools)
- [x] PLAN updated (quality PR section added)