### PR TITLE
Quality parity with proxmox-mcp

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,22 @@
+name: Vulnerability check
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/.github/workflows/test-latest.yml
+++ b/.github/workflows/test-latest.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod

--- a/.github/workflows/test-latest.yml
+++ b/.github/workflows/test-latest.yml
@@ -1,0 +1,22 @@
+name: Test with latest dependencies
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  test-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Upgrade all dependencies to latest
+        run: go get -u -t ./...
+      - name: Tidy
+        run: go mod tidy
+      - name: Test
+        run: go test -race -count=1 ./...

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 BINARY := bin/truenas-mcp
-CMD     := ./cmd/truenas-mcp
+CMD    := ./cmd/truenas-mcp
+
+GOFUMPT_VERSION      := v0.7.0
+GOSEC_VERSION        := v2.22.8
+GOVULNCHECK_VERSION  := v1.1.4
+GOLANGCILINT_VERSION := v2.10.1
 
 .PHONY: all install-tools fix fmt vet lint sec vulncheck test build check clean
 
@@ -7,10 +12,10 @@ all: check
 
 ## install-tools – installs all required dev tools
 install-tools:
-	go install mvdan.cc/gofumpt@latest
-	go install github.com/securego/gosec/v2/cmd/gosec@latest
-	go install golang.org/x/vuln/cmd/govulncheck@latest
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
+	go install github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)
+	go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCILINT_VERSION)
 
 ## fix – apply go fix to update deprecated API usage
 fix:

--- a/PLAN.md
+++ b/PLAN.md
@@ -166,8 +166,6 @@ any changes to the `tools/` layer.
 
 ---
 
----
-
 ## PR 2 — Quality parity with proxmox-mcp
 
 **Goal**: Bring truenas-mcp up to the same quality standard as proxmox-mcp after its

--- a/PLAN.md
+++ b/PLAN.md
@@ -166,6 +166,57 @@ any changes to the `tools/` layer.
 
 ---
 
+---
+
+## PR 2 — Quality parity with proxmox-mcp
+
+**Goal**: Bring truenas-mcp up to the same quality standard as proxmox-mcp after its
+hardening pass.
+
+**Tasks**:
+
+- ✅ **`tools/client_iface.go`** — Extract `truenasClient` interface (35 methods) over
+  `*truenas.Client`; allows mock-based testing without a live TrueNAS server. All
+  `register*Tools` functions and `RegisterAll` now accept `truenasClient` instead of
+  `*truenas.Client`.
+
+- ✅ **`tools/helpers.go`** — Add `errorResult(err error)` helper (same pattern as
+  proxmox-mcp). All tool handlers now use `return errorResult(...)` instead of
+  `return nil, nil, err`, so tool execution errors flow as `isError: true` per MCP spec §6.
+
+- ✅ **`tools/mock_client_test.go`** — `mockTruenasClient` struct with one `*Fn`
+  callback field per interface method; nil fields return zero values.
+
+- ✅ **`tools/tooltest_test.go`** — `connectTestServer`, `callTool`, `assertSuccess`,
+  `assertError`, `assertResultJSON` — identical pattern to proxmox-mcp.
+
+- ✅ **`tools/*_test.go`** (9 files) — Round-trip tool tests for all 9 tool domains
+  (system, pool, dataset, snapshot, vm, app, network, filesystem, destructive).
+  132 tests total; covers happy path, error path, and input validation per tool.
+
+- ✅ **`internal/truenas/client.go`** — Add `maxMessageBytes = 10 MiB` constant and
+  call `conn.SetReadLimit(maxMessageBytes)` immediately after the WebSocket connection
+  is established. This caps inbound WebSocket message size, preventing memory exhaustion
+  from abnormally large server responses.
+
+- ✅ **`cmd/truenas-mcp/main.go`** — HTTP server hardening:
+  - `ReadTimeout: 60s` (was missing)
+  - `IdleTimeout: 120s` (was missing)
+  - `MaxHeaderBytes: 1 MiB` (was missing)
+  - `http.MaxBytesHandler(handler, 4 MiB)` wrapper (was missing)
+  - `!errors.Is(err, http.ErrServerClosed)` instead of `!= http.ErrServerClosed`
+
+- ✅ **`Makefile`** — Pin all dev tool versions to explicit semver tags instead of
+  `@latest` to prevent surprise CI breakage on new tool releases.
+
+- ✅ **`.github/workflows/test-latest.yml`** — Daily workflow: upgrade all deps to
+  latest, run tests. Catches breakage before users do.
+
+- ✅ **`.github/workflows/govulncheck.yml`** — Daily vulnerability check via
+  `govulncheck`. Separate job so vuln alerts don't block regular CI.
+
+---
+
 ## Security Rules
 
 - No credentials in source — env vars only

--- a/cmd/truenas-mcp/main.go
+++ b/cmd/truenas-mcp/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -102,12 +103,17 @@ func run() error {
 			return server
 		}, nil)
 		httpServer := &http.Server{
-			Addr:              *addr,
-			Handler:           handler,
+			Addr:    *addr,
+			Handler: http.MaxBytesHandler(handler, 4<<20),
+			// ReadTimeout must leave room for slow clients sending large bodies.
+			ReadTimeout: 60 * time.Second,
+			// ReadHeaderTimeout is a tighter guard against Slowloris attacks.
 			ReadHeaderTimeout: 30 * time.Second,
 			// WriteTimeout must exceed the TrueNAS API client timeout (30s) plus
 			// any job-polling time so that in-flight responses are never cut short.
 			WriteTimeout: 90 * time.Second,
+			IdleTimeout:  120 * time.Second,
+			MaxHeaderBytes: 1 << 20,
 		}
 		slog.Info("truenas-mcp listening", "addr", *addr, "transport", "http")
 		go func() {
@@ -118,7 +124,7 @@ func run() error {
 				slog.Warn("HTTP server shutdown error", "err", shutdownErr)
 			}
 		}()
-		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			return fmt.Errorf("http server: %w", err)
 		}
 	default:

--- a/internal/truenas/app.go
+++ b/internal/truenas/app.go
@@ -38,7 +38,7 @@ type App struct {
 // Image represents a Docker image stored on TrueNAS SCALE.
 type Image struct {
 	ID       string   `json:"id"`
-	RepoTags []string `json:"repo_tags"`
+	RepoTags []string `json:"repo_tags,omitempty"`
 	Size     int64    `json:"size"`
 }
 
@@ -59,12 +59,12 @@ type AppVersionInfo struct {
 // UpgradeAvailable is false when the app is already on the latest version.
 type AppUpgradeSummary struct {
 	UpgradeAvailable            bool             `json:"upgrade_available"`
-	LatestVersion               string           `json:"latest_version"`
-	LatestHumanVersion          string           `json:"latest_human_version"`
-	UpgradeVersion              string           `json:"upgrade_version"`
-	UpgradeHumanVersion         string           `json:"upgrade_human_version"`
-	AvailableVersionsForUpgrade []AppVersionInfo `json:"available_versions_for_upgrade"`
-	Changelog                   *string          `json:"changelog"`
+	LatestVersion               string           `json:"latest_version,omitempty"`
+	LatestHumanVersion          string           `json:"latest_human_version,omitempty"`
+	UpgradeVersion              string           `json:"upgrade_version,omitempty"`
+	UpgradeHumanVersion         string           `json:"upgrade_human_version,omitempty"`
+	AvailableVersionsForUpgrade []AppVersionInfo `json:"available_versions_for_upgrade,omitempty"`
+	Changelog                   *string          `json:"changelog,omitempty"`
 }
 
 // ListApps returns all installed apps on the TrueNAS SCALE system.

--- a/internal/truenas/client.go
+++ b/internal/truenas/client.go
@@ -17,7 +17,8 @@ import (
 
 const (
 	wsHandshakeTimeout = 10 * time.Second
-	defaultCallTimeout = 30 * time.Second // applied when ctx has no deadline
+	defaultCallTimeout = 30 * time.Second  // applied when ctx has no deadline
+	maxMessageBytes    = 10 * 1024 * 1024  // 10 MiB cap on inbound WebSocket messages
 )
 
 // rpcRequest is a JSON-RPC 2.0 request frame sent to TrueNAS.
@@ -146,6 +147,7 @@ func (c *Client) Connect(ctx context.Context) error {
 		_ = conn.Close()
 		return fmt.Errorf("Connect called on an already-connected client")
 	}
+	conn.SetReadLimit(maxMessageBytes)
 	c.conn = conn
 	c.mu.Unlock()
 

--- a/internal/truenas/dataset.go
+++ b/internal/truenas/dataset.go
@@ -2,6 +2,7 @@ package truenas
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
@@ -15,20 +16,31 @@ type DatasetValue struct {
 	Parsed   any    `json:"parsed"`
 }
 
+// MarshalJSON emits just the human-readable Value string (e.g. "11.61 TiB",
+// "lz4") instead of the full {value, rawvalue, parsed} object. When Value is
+// empty (field not set, e.g. quota with no quota) null is emitted. This cuts
+// token cost roughly 5× compared to the full wrapper object.
+func (v DatasetValue) MarshalJSON() ([]byte, error) {
+	if v.Value == "" {
+		return []byte("null"), nil
+	}
+	return json.Marshal(v.Value)
+}
+
 // Dataset represents a ZFS dataset or zvol on TrueNAS SCALE.
 type Dataset struct {
 	ID          string       `json:"id"`
 	Name        string       `json:"name"`
 	Pool        string       `json:"pool"`
 	Type        string       `json:"type"` // FILESYSTEM or VOLUME
-	MountPoint  *string      `json:"mountpoint"`
+	MountPoint  *string      `json:"mountpoint,omitempty"`
 	Encrypted   bool         `json:"encrypted"`
 	Available   DatasetValue `json:"available"`
 	Used        DatasetValue `json:"used"`
-	Quota       DatasetValue `json:"quota"`
+	Quota       DatasetValue `json:"quota,omitempty"`
 	Compression DatasetValue `json:"compression"`
-	Comments    DatasetValue `json:"comments"`
-	Children    []Dataset    `json:"children"`
+	Comments    DatasetValue `json:"comments,omitempty"`
+	Children    []Dataset    `json:"children,omitempty"`
 }
 
 // CreateDatasetParams holds the fields required and optional for creating a

--- a/internal/truenas/dataset.go
+++ b/internal/truenas/dataset.go
@@ -37,6 +37,10 @@ type Dataset struct {
 	Encrypted   bool         `json:"encrypted"`
 	Available   DatasetValue `json:"available"`
 	Used        DatasetValue `json:"used"`
+	// Quota and Comments use omitempty, but because DatasetValue is a struct
+	// omitempty only fires for the exact zero value. In practice TrueNAS returns
+	// a non-zero DatasetValue even for unset quotas ({value:"",rawvalue:"0",...}),
+	// so these fields appear as null (from MarshalJSON) rather than being omitted.
 	Quota       DatasetValue `json:"quota,omitempty"`
 	Compression DatasetValue `json:"compression"`
 	Comments    DatasetValue `json:"comments,omitempty"`

--- a/internal/truenas/dataset_test.go
+++ b/internal/truenas/dataset_test.go
@@ -7,6 +7,33 @@ import (
 	"testing"
 )
 
+func TestDatasetValue_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input DatasetValue
+		want  string
+	}{
+		{"non-empty value", DatasetValue{Value: "11.59 TiB", RawValue: "12742033547264"}, `"11.59 TiB"`},
+		{"compression string", DatasetValue{Value: "lz4", RawValue: "lz4"}, `"lz4"`},
+		{"empty value emits null", DatasetValue{Value: "", RawValue: "0"}, "null"},
+		{"zero value emits null", DatasetValue{}, "null"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(tc.input)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestListDatasets_success(t *testing.T) {
 	t.Parallel()
 

--- a/internal/truenas/filesystem.go
+++ b/internal/truenas/filesystem.go
@@ -10,7 +10,7 @@ import (
 type DirEntry struct {
 	Name     string `json:"name"`
 	Path     string `json:"path"`
-	RealPath string `json:"realpath"`
+	RealPath string `json:"realpath,omitempty"`
 	// Type is "FILE" or "DIRECTORY".
 	Type string `json:"type"`
 	Size int64  `json:"size"`

--- a/internal/truenas/network.go
+++ b/internal/truenas/network.go
@@ -19,8 +19,8 @@ type Interface struct {
 	Name string `json:"name"`
 	// Type is the interface kind: PHYSICAL, BRIDGE, BOND, VLAN, etc.
 	Type        string           `json:"type"`
-	Description string           `json:"description"`
-	Aliases     []InterfaceAlias `json:"aliases"`
+	Description string           `json:"description,omitempty"`
+	Aliases     []InterfaceAlias `json:"aliases,omitempty"`
 }
 
 // ListInterfaces returns all network interfaces configured on the TrueNAS host.

--- a/internal/truenas/pool.go
+++ b/internal/truenas/pool.go
@@ -23,11 +23,11 @@ type Pool struct {
 	Healthy       bool     `json:"healthy"`
 	Warning       bool     `json:"warning"`
 	StatusCode    string   `json:"status_code"`
-	StatusDetail  *string  `json:"status_detail"`
+	StatusDetail  *string  `json:"status_detail,omitempty"`
 	Size          int64    `json:"size"`
 	Allocated     int64    `json:"allocated"`
 	Free          int64    `json:"free"`
-	Freeing       int64    `json:"freeing"`
+	Freeing       int64    `json:"freeing,omitempty"`
 	Fragmentation string   `json:"fragmentation"`
 	Scan          PoolScan `json:"scan"`
 }

--- a/internal/truenas/pool.go
+++ b/internal/truenas/pool.go
@@ -27,7 +27,7 @@ type Pool struct {
 	Size          int64    `json:"size"`
 	Allocated     int64    `json:"allocated"`
 	Free          int64    `json:"free"`
-	Freeing       int64    `json:"freeing,omitempty"`
+	Freeing       int64    `json:"freeing"`
 	Fragmentation string   `json:"fragmentation"`
 	Scan          PoolScan `json:"scan"`
 }

--- a/internal/truenas/snapshot.go
+++ b/internal/truenas/snapshot.go
@@ -14,11 +14,11 @@ type Snapshot struct {
 	Dataset    string   `json:"dataset"`
 	Name       string   `json:"snapshot_name"`
 	Pool       string   `json:"pool"`
-	Referenced string   `json:"referenced"`
-	Used       string   `json:"used"`
-	CreateTXG  string   `json:"createtxg"`
-	GUID       string   `json:"guid"`
-	Clones     []string `json:"clones"`
+	Referenced string   `json:"referenced,omitempty"`
+	Used       string   `json:"used,omitempty"`
+	CreateTXG  string   `json:"createtxg,omitempty"`
+	GUID       string   `json:"guid,omitempty"`
+	Clones     []string `json:"clones,omitempty"`
 }
 
 // CreateSnapshotParams holds the fields for creating a ZFS snapshot.

--- a/internal/truenas/vm.go
+++ b/internal/truenas/vm.go
@@ -12,16 +12,16 @@ var vmNameRe = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
 
 // VMStatus holds the runtime state of a VM as reported by TrueNAS SCALE.
 type VMStatus struct {
-	State       string `json:"state"`        // RUNNING, STOPPED
-	PID         *int   `json:"pid"`          // nil when not running
-	DomainState string `json:"domain_state"` // libvirt domain state string
+	State       string `json:"state"`                  // RUNNING, STOPPED
+	PID         *int   `json:"pid,omitempty"`          // nil when not running
+	DomainState string `json:"domain_state,omitempty"` // libvirt domain state string
 }
 
 // VM represents a virtual machine configured on TrueNAS SCALE.
 type VM struct {
 	ID              int      `json:"id"`
 	Name            string   `json:"name"`
-	Description     string   `json:"description"`
+	Description     string   `json:"description,omitempty"`
 	VCPUs           int      `json:"vcpus"`
 	Memory          int      `json:"memory"` // MiB
 	Autostart       bool     `json:"autostart"`
@@ -29,9 +29,9 @@ type VM struct {
 	Cores           int      `json:"cores"`
 	Threads         int      `json:"threads"`
 	ShutdownTimeout int      `json:"shutdown_timeout"`
-	CPUMode         string   `json:"cpu_mode"`
-	CPUModel        string   `json:"cpu_model"`
-	UUID            string   `json:"uuid"`
+	CPUMode         string   `json:"cpu_mode,omitempty"`
+	CPUModel        string   `json:"cpu_model,omitempty"`
+	UUID            string   `json:"uuid,omitempty"`
 	Status          VMStatus `json:"status"`
 }
 

--- a/tools/app.go
+++ b/tools/app.go
@@ -10,7 +10,7 @@ import (
 )
 
 // registerAppTools adds TrueNAS app and Docker image MCP tools to the server.
-func registerAppTools(s *mcp.Server, client *truenas.Client) {
+func registerAppTools(s *mcp.Server, client truenasClient) {
 	type listAppsInput struct {
 		Limit  int `json:"limit,omitempty"  jsonschema:"Maximum number of apps to return; 0 means no limit"`
 		Offset int `json:"offset,omitempty" jsonschema:"Number of apps to skip; 0 means start from the beginning"`
@@ -22,7 +22,7 @@ func registerAppTools(s *mcp.Server, client *truenas.Client) {
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p listAppsInput) (*mcp.CallToolResult, any, error) {
 		apps, err := client.ListApps(ctx, truenas.ListOptions{Limit: p.Limit, Offset: p.Offset})
 		if err != nil {
-			return nil, nil, fmt.Errorf("list_apps: %w", err)
+			return errorResult(fmt.Errorf("list_apps: %w", err))
 		}
 		return jsonResult(apps)
 	})
@@ -36,14 +36,14 @@ func registerAppTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p getAppInput) (*mcp.CallToolResult, any, error) {
 		if p.Name == "" {
-			return nil, nil, errors.New("get_app: name must not be empty")
+			return errorResult(errors.New("get_app: name must not be empty"))
 		}
 		app, err := client.GetApp(ctx, p.Name)
 		if err != nil {
 			if errors.Is(err, truenas.ErrNotFound) {
-				return nil, nil, fmt.Errorf("get_app: app %q not found", p.Name)
+				return errorResult(fmt.Errorf("get_app: app %q not found", p.Name))
 			}
-			return nil, nil, fmt.Errorf("get_app: %w", err)
+			return errorResult(fmt.Errorf("get_app: %w", err))
 		}
 		return jsonResult(app)
 	})
@@ -57,11 +57,11 @@ func registerAppTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p startAppInput) (*mcp.CallToolResult, any, error) {
 		if p.Name == "" {
-			return nil, nil, errors.New("start_app: name must not be empty")
+			return errorResult(errors.New("start_app: name must not be empty"))
 		}
 		jobID, err := client.StartApp(ctx, p.Name)
 		if err != nil {
-			return nil, nil, fmt.Errorf("start_app: %w", err)
+			return errorResult(fmt.Errorf("start_app: %w", err))
 		}
 		return jsonResult(map[string]int{"job_id": jobID})
 	})
@@ -75,11 +75,11 @@ func registerAppTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p stopAppInput) (*mcp.CallToolResult, any, error) {
 		if p.Name == "" {
-			return nil, nil, errors.New("stop_app: name must not be empty")
+			return errorResult(errors.New("stop_app: name must not be empty"))
 		}
 		jobID, err := client.StopApp(ctx, p.Name)
 		if err != nil {
-			return nil, nil, fmt.Errorf("stop_app: %w", err)
+			return errorResult(fmt.Errorf("stop_app: %w", err))
 		}
 		return jsonResult(map[string]int{"job_id": jobID})
 	})
@@ -93,11 +93,11 @@ func registerAppTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p restartAppInput) (*mcp.CallToolResult, any, error) {
 		if p.Name == "" {
-			return nil, nil, errors.New("restart_app: name must not be empty")
+			return errorResult(errors.New("restart_app: name must not be empty"))
 		}
 		jobID, err := client.RestartApp(ctx, p.Name)
 		if err != nil {
-			return nil, nil, fmt.Errorf("restart_app: %w", err)
+			return errorResult(fmt.Errorf("restart_app: %w", err))
 		}
 		return jsonResult(map[string]int{"job_id": jobID})
 	})
@@ -110,7 +110,7 @@ func registerAppTools(s *mcp.Server, client *truenas.Client) {
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ listImagesInput) (*mcp.CallToolResult, any, error) {
 		images, err := client.ListImages(ctx)
 		if err != nil {
-			return nil, nil, fmt.Errorf("list_images: %w", err)
+			return errorResult(fmt.Errorf("list_images: %w", err))
 		}
 		return jsonResult(images)
 	})
@@ -127,10 +127,10 @@ func registerAppTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p installAppInput) (*mcp.CallToolResult, any, error) {
 		if p.AppName == "" {
-			return nil, nil, errors.New("install_app: app_name must not be empty")
+			return errorResult(errors.New("install_app: app_name must not be empty"))
 		}
 		if p.CatalogApp == "" {
-			return nil, nil, errors.New("install_app: catalog_app must not be empty")
+			return errorResult(errors.New("install_app: catalog_app must not be empty"))
 		}
 		train := p.Train
 		if train == "" {
@@ -147,7 +147,7 @@ func registerAppTools(s *mcp.Server, client *truenas.Client) {
 			Version:    version,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("install_app: %w", err)
+			return errorResult(fmt.Errorf("install_app: %w", err))
 		}
 		return jsonResult(map[string]int{"job_id": jobID})
 	})
@@ -162,10 +162,10 @@ func registerAppTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p installCustomAppInput) (*mcp.CallToolResult, any, error) {
 		if p.AppName == "" {
-			return nil, nil, errors.New("install_custom_app: app_name must not be empty")
+			return errorResult(errors.New("install_custom_app: app_name must not be empty"))
 		}
 		if p.CustomComposeConfigString == "" {
-			return nil, nil, errors.New("install_custom_app: custom_compose_config_string must not be empty")
+			return errorResult(errors.New("install_custom_app: custom_compose_config_string must not be empty"))
 		}
 		jobID, err := client.CreateApp(ctx, &truenas.CreateAppParams{
 			AppName:                   p.AppName,
@@ -173,7 +173,7 @@ func registerAppTools(s *mcp.Server, client *truenas.Client) {
 			CustomComposeConfigString: p.CustomComposeConfigString,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("install_custom_app: %w", err)
+			return errorResult(fmt.Errorf("install_custom_app: %w", err))
 		}
 		return jsonResult(map[string]int{"job_id": jobID})
 	})
@@ -188,11 +188,11 @@ func registerAppTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p upgradeAppInput) (*mcp.CallToolResult, any, error) {
 		if p.Name == "" {
-			return nil, nil, errors.New("upgrade_app: name must not be empty")
+			return errorResult(errors.New("upgrade_app: name must not be empty"))
 		}
 		jobID, err := client.UpgradeApp(ctx, p.Name, p.Version)
 		if err != nil {
-			return nil, nil, fmt.Errorf("upgrade_app: %w", err)
+			return errorResult(fmt.Errorf("upgrade_app: %w", err))
 		}
 		return jsonResult(map[string]int{"job_id": jobID})
 	})
@@ -206,11 +206,11 @@ func registerAppTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p upgradeSummaryInput) (*mcp.CallToolResult, any, error) {
 		if p.Name == "" {
-			return nil, nil, errors.New("upgrade_summary: name must not be empty")
+			return errorResult(errors.New("upgrade_summary: name must not be empty"))
 		}
 		summary, err := client.GetUpgradeSummary(ctx, p.Name)
 		if err != nil {
-			return nil, nil, fmt.Errorf("upgrade_summary: %w", err)
+			return errorResult(fmt.Errorf("upgrade_summary: %w", err))
 		}
 		return jsonResult(summary)
 	})
@@ -225,14 +225,14 @@ func registerAppTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p rollbackAppInput) (*mcp.CallToolResult, any, error) {
 		if p.Name == "" {
-			return nil, nil, errors.New("rollback_app: name must not be empty")
+			return errorResult(errors.New("rollback_app: name must not be empty"))
 		}
 		if p.Version == "" {
-			return nil, nil, errors.New("rollback_app: version must not be empty")
+			return errorResult(errors.New("rollback_app: version must not be empty"))
 		}
 		jobID, err := client.RollbackApp(ctx, p.Name, p.Version)
 		if err != nil {
-			return nil, nil, fmt.Errorf("rollback_app: %w", err)
+			return errorResult(fmt.Errorf("rollback_app: %w", err))
 		}
 		return jsonResult(map[string]int{"job_id": jobID})
 	})

--- a/tools/app_test.go
+++ b/tools/app_test.go
@@ -1,0 +1,310 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+)
+
+func TestListApps(t *testing.T) {
+	t.Run("returns apps as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listAppsFn: func(_ context.Context, _ ...truenas.ListOptions) ([]truenas.App, error) {
+				return []truenas.App{{Name: "jellyfin"}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_apps", nil)
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listAppsFn: func(_ context.Context, _ ...truenas.ListOptions) ([]truenas.App, error) {
+				return nil, errors.New("API error")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_apps", nil)
+		assertError(t, res, "API error")
+	})
+}
+
+func TestGetApp(t *testing.T) {
+	t.Run("returns app as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			getAppFn: func(_ context.Context, name string) (*truenas.App, error) {
+				return &truenas.App{Name: name}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_app", map[string]any{"name": "jellyfin"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "get_app", map[string]any{"name": ""})
+		assertError(t, res, "name must not be empty")
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			getAppFn: func(_ context.Context, _ string) (*truenas.App, error) {
+				return nil, errors.New("app not found")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_app", map[string]any{"name": "noexist"})
+		assertError(t, res, "app not found")
+	})
+}
+
+func TestStartApp(t *testing.T) {
+	t.Run("returns job ID as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			startAppFn: func(_ context.Context, _ string) (int, error) {
+				return 10, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "start_app", map[string]any{"name": "jellyfin"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "start_app", map[string]any{"name": ""})
+		assertError(t, res, "name must not be empty")
+	})
+}
+
+func TestStopApp(t *testing.T) {
+	t.Run("returns job ID as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			stopAppFn: func(_ context.Context, _ string) (int, error) {
+				return 11, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "stop_app", map[string]any{"name": "jellyfin"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "stop_app", map[string]any{"name": ""})
+		assertError(t, res, "name must not be empty")
+	})
+}
+
+func TestRestartApp(t *testing.T) {
+	t.Run("returns job ID as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			restartAppFn: func(_ context.Context, _ string) (int, error) {
+				return 12, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "restart_app", map[string]any{"name": "jellyfin"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "restart_app", map[string]any{"name": ""})
+		assertError(t, res, "name must not be empty")
+	})
+}
+
+func TestListImages(t *testing.T) {
+	t.Run("returns images as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listImagesFn: func(_ context.Context) ([]truenas.Image, error) {
+				return []truenas.Image{{ID: "jellyfin/jellyfin:latest"}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_images", nil)
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listImagesFn: func(_ context.Context) ([]truenas.Image, error) {
+				return nil, errors.New("docker not available")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_images", nil)
+		assertError(t, res, "docker not available")
+	})
+}
+
+func TestInstallApp(t *testing.T) {
+	t.Run("returns job ID as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			createAppFn: func(_ context.Context, _ *truenas.CreateAppParams) (int, error) {
+				return 20, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "install_app", map[string]any{
+			"app_name":    "my-jellyfin",
+			"catalog_app": "jellyfin",
+		})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty app_name returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "install_app", map[string]any{"app_name": "", "catalog_app": "jellyfin"})
+		assertError(t, res, "app_name must not be empty")
+	})
+
+	t.Run("empty catalog_app returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "install_app", map[string]any{"app_name": "my-app", "catalog_app": ""})
+		assertError(t, res, "catalog_app must not be empty")
+	})
+}
+
+func TestInstallCustomApp(t *testing.T) {
+	t.Run("returns job ID as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			createAppFn: func(_ context.Context, _ *truenas.CreateAppParams) (int, error) {
+				return 21, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "install_custom_app", map[string]any{
+			"app_name":                    "my-app",
+			"custom_compose_config_string": "services:\n  web:\n    image: nginx\n",
+		})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty app_name returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "install_custom_app", map[string]any{
+			"app_name":                    "",
+			"custom_compose_config_string": "services: {}",
+		})
+		assertError(t, res, "app_name must not be empty")
+	})
+}
+
+func TestUpgradeApp(t *testing.T) {
+	t.Run("returns job ID as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			upgradeAppFn: func(_ context.Context, _, _ string) (int, error) {
+				return 30, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "upgrade_app", map[string]any{"name": "jellyfin"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "upgrade_app", map[string]any{"name": ""})
+		assertError(t, res, "name must not be empty")
+	})
+}
+
+func TestUpgradeSummary(t *testing.T) {
+	t.Run("returns summary as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			getUpgradeSummaryFn: func(_ context.Context, name string) (*truenas.AppUpgradeSummary, error) {
+				return &truenas.AppUpgradeSummary{LatestVersion: "1.2.0"}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "upgrade_summary", map[string]any{"name": "jellyfin"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "upgrade_summary", map[string]any{"name": ""})
+		assertError(t, res, "name must not be empty")
+	})
+}
+
+func TestRollbackApp(t *testing.T) {
+	t.Run("returns job ID as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			rollbackAppFn: func(_ context.Context, _, _ string) (int, error) {
+				return 31, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "rollback_app", map[string]any{"name": "jellyfin", "version": "1.1.0"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "rollback_app", map[string]any{"name": "", "version": "1.1.0"})
+		assertError(t, res, "name must not be empty")
+	})
+
+	t.Run("empty version returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "rollback_app", map[string]any{"name": "jellyfin", "version": ""})
+		assertError(t, res, "version must not be empty")
+	})
+}

--- a/tools/client_iface.go
+++ b/tools/client_iface.go
@@ -1,0 +1,62 @@
+package tools
+
+import (
+	"context"
+
+	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+)
+
+// truenasClient is the subset of *truenas.Client used by the tools layer.
+// It exists to allow mock implementations in tests without requiring a live TrueNAS server.
+type truenasClient interface {
+	// System
+	GetSystemInfo(ctx context.Context) (*truenas.SystemInfo, error)
+
+	// Pools
+	ListPools(ctx context.Context, opts ...truenas.ListOptions) ([]truenas.Pool, error)
+	GetPool(ctx context.Context, id int) (*truenas.Pool, error)
+
+	// Datasets
+	ListDatasets(ctx context.Context, pool string, opts ...truenas.ListOptions) ([]truenas.Dataset, error)
+	GetDataset(ctx context.Context, id string) (*truenas.Dataset, error)
+	CreateDataset(ctx context.Context, params *truenas.CreateDatasetParams) (*truenas.Dataset, error)
+
+	// Snapshots
+	ListSnapshots(ctx context.Context, dataset string, opts ...truenas.ListOptions) ([]truenas.Snapshot, error)
+	GetSnapshot(ctx context.Context, id string) (*truenas.Snapshot, error)
+	CreateSnapshot(ctx context.Context, params truenas.CreateSnapshotParams) (*truenas.Snapshot, error)
+	RollbackSnapshot(ctx context.Context, id string, params truenas.RollbackSnapshotParams) error
+	DeleteSnapshot(ctx context.Context, id string) error
+
+	// Virtual Machines
+	ListVMs(ctx context.Context, opts ...truenas.ListOptions) ([]truenas.VM, error)
+	GetVM(ctx context.Context, id int) (*truenas.VM, error)
+	StartVM(ctx context.Context, id int) (int, error)
+	StopVM(ctx context.Context, id int, force bool) (int, error)
+	RestartVM(ctx context.Context, id int) (int, error)
+	CreateVM(ctx context.Context, params *truenas.CreateVMParams) (*truenas.VM, error)
+	UpdateVM(ctx context.Context, id int, params *truenas.UpdateVMParams) (*truenas.VM, error)
+	DeleteVM(ctx context.Context, id int) error
+	ListVMDevices(ctx context.Context, vmID int) ([]truenas.VMDevice, error)
+	AddVMDevice(ctx context.Context, params *truenas.AddVMDeviceParams) (*truenas.VMDevice, error)
+	DeleteVMDevice(ctx context.Context, deviceID int) error
+
+	// Apps
+	ListApps(ctx context.Context, opts ...truenas.ListOptions) ([]truenas.App, error)
+	GetApp(ctx context.Context, name string) (*truenas.App, error)
+	StartApp(ctx context.Context, name string) (int, error)
+	StopApp(ctx context.Context, name string) (int, error)
+	RestartApp(ctx context.Context, name string) (int, error)
+	ListImages(ctx context.Context) ([]truenas.Image, error)
+	CreateApp(ctx context.Context, params *truenas.CreateAppParams) (int, error)
+	DeleteApp(ctx context.Context, name string) error
+	UpgradeApp(ctx context.Context, name, version string) (int, error)
+	GetUpgradeSummary(ctx context.Context, name string) (*truenas.AppUpgradeSummary, error)
+	RollbackApp(ctx context.Context, name, version string) (int, error)
+
+	// Network
+	ListInterfaces(ctx context.Context) ([]truenas.Interface, error)
+
+	// Filesystem
+	ListDirectory(ctx context.Context, path string) ([]truenas.DirEntry, error)
+}

--- a/tools/dataset.go
+++ b/tools/dataset.go
@@ -5,13 +5,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // registerDatasetTools registers all dataset-related MCP tools onto the server.
-func registerDatasetTools(s *mcp.Server, client *truenas.Client) {
+func registerDatasetTools(s *mcp.Server, client truenasClient) {
 	type listDatasetsInput struct {
 		// Pool filters the results to datasets belonging to this pool name.
 		// Leave empty to return datasets from all pools.
@@ -27,7 +26,7 @@ func registerDatasetTools(s *mcp.Server, client *truenas.Client) {
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p listDatasetsInput) (*mcp.CallToolResult, any, error) {
 		datasets, err := client.ListDatasets(ctx, p.Pool, truenas.ListOptions{Limit: p.Limit, Offset: p.Offset})
 		if err != nil {
-			return nil, nil, fmt.Errorf("list_datasets: %w", err)
+			return errorResult(fmt.Errorf("list_datasets: %w", err))
 		}
 		return jsonResult(datasets)
 	})
@@ -43,14 +42,14 @@ func registerDatasetTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p getDatasetInput) (*mcp.CallToolResult, any, error) {
 		if p.ID == "" {
-			return nil, nil, errors.New("get_dataset: id must not be empty")
+			return errorResult(errors.New("get_dataset: id must not be empty"))
 		}
 		dataset, err := client.GetDataset(ctx, p.ID)
 		if err != nil {
 			if errors.Is(err, truenas.ErrNotFound) {
-				return nil, nil, fmt.Errorf("get_dataset: dataset %q not found", p.ID)
+				return errorResult(fmt.Errorf("get_dataset: dataset %q not found", p.ID))
 			}
-			return nil, nil, fmt.Errorf("get_dataset: %w", err)
+			return errorResult(fmt.Errorf("get_dataset: %w", err))
 		}
 		return jsonResult(dataset)
 	})
@@ -76,7 +75,7 @@ func registerDatasetTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p createDatasetInput) (*mcp.CallToolResult, any, error) {
 		if p.Name == "" {
-			return nil, nil, errors.New("create_dataset: name must not be empty")
+			return errorResult(errors.New("create_dataset: name must not be empty"))
 		}
 		dataset, err := client.CreateDataset(ctx, &truenas.CreateDatasetParams{
 			Name:        p.Name,
@@ -87,7 +86,7 @@ func registerDatasetTools(s *mcp.Server, client *truenas.Client) {
 			Volsize:     p.Volsize,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("create_dataset: %w", err)
+			return errorResult(fmt.Errorf("create_dataset: %w", err))
 		}
 		return jsonResult(dataset)
 	})

--- a/tools/dataset_test.go
+++ b/tools/dataset_test.go
@@ -1,0 +1,109 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+)
+
+func TestListDatasets(t *testing.T) {
+	t.Run("returns datasets as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listDatasetsFn: func(_ context.Context, _ string, _ ...truenas.ListOptions) ([]truenas.Dataset, error) {
+				return []truenas.Dataset{{ID: "tank/data"}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_datasets", nil)
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listDatasetsFn: func(_ context.Context, _ string, _ ...truenas.ListOptions) ([]truenas.Dataset, error) {
+				return nil, errors.New("API error")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_datasets", nil)
+		assertError(t, res, "API error")
+	})
+}
+
+func TestGetDataset(t *testing.T) {
+	t.Run("returns dataset as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			getDatasetFn: func(_ context.Context, id string) (*truenas.Dataset, error) {
+				return &truenas.Dataset{ID: id}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_dataset", map[string]any{"id": "tank/data"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty id returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "get_dataset", map[string]any{"id": ""})
+		assertError(t, res, "id must not be empty")
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			getDatasetFn: func(_ context.Context, _ string) (*truenas.Dataset, error) {
+				return nil, errors.New("dataset not found")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_dataset", map[string]any{"id": "tank/noexist"})
+		assertError(t, res, "dataset not found")
+	})
+}
+
+func TestCreateDataset(t *testing.T) {
+	t.Run("returns created dataset as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			createDatasetFn: func(_ context.Context, p *truenas.CreateDatasetParams) (*truenas.Dataset, error) {
+				return &truenas.Dataset{ID: p.Name}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "create_dataset", map[string]any{"name": "tank/backups"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "create_dataset", map[string]any{"name": ""})
+		assertError(t, res, "name must not be empty")
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			createDatasetFn: func(_ context.Context, _ *truenas.CreateDatasetParams) (*truenas.Dataset, error) {
+				return nil, errors.New("dataset already exists")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "create_dataset", map[string]any{"name": "tank/dup"})
+		assertError(t, res, "dataset already exists")
+	})
+}

--- a/tools/destructive.go
+++ b/tools/destructive.go
@@ -5,14 +5,13 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // registerDestructiveTools adds opt-in destructive tools to the server.
 // These tools are only registered when TRUENAS_ALLOW_DESTRUCTIVE=true.
-func registerDestructiveTools(s *mcp.Server, client *truenas.Client) {
+func registerDestructiveTools(s *mcp.Server, client truenasClient) {
 	destructiveHint := true
 	type deleteVMInput struct {
 		ID        int  `json:"id"        jsonschema:"Numeric VM ID"`
@@ -28,13 +27,13 @@ func registerDestructiveTools(s *mcp.Server, client *truenas.Client) {
 		},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p deleteVMInput) (*mcp.CallToolResult, any, error) {
 		if !p.Confirmed {
-			return nil, nil, errors.New("delete_vm: confirmed must be true to proceed with deletion")
+			return errorResult(errors.New("delete_vm: confirmed must be true to proceed with deletion"))
 		}
 		if p.ID <= 0 {
-			return nil, nil, errors.New("delete_vm: id must be a positive integer")
+			return errorResult(errors.New("delete_vm: id must be a positive integer"))
 		}
 		if err := client.DeleteVM(ctx, p.ID); err != nil {
-			return nil, nil, fmt.Errorf("delete_vm: %w", err)
+			return errorResult(fmt.Errorf("delete_vm: %w", err))
 		}
 		return jsonResult(map[string]any{"deleted": true, "id": p.ID})
 	})
@@ -53,13 +52,13 @@ func registerDestructiveTools(s *mcp.Server, client *truenas.Client) {
 		},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p deleteAppInput) (*mcp.CallToolResult, any, error) {
 		if !p.Confirmed {
-			return nil, nil, errors.New("delete_app: confirmed must be true to proceed with deletion")
+			return errorResult(errors.New("delete_app: confirmed must be true to proceed with deletion"))
 		}
 		if p.Name == "" {
-			return nil, nil, errors.New("delete_app: name must not be empty")
+			return errorResult(errors.New("delete_app: name must not be empty"))
 		}
 		if err := client.DeleteApp(ctx, p.Name); err != nil {
-			return nil, nil, fmt.Errorf("delete_app: %w", err)
+			return errorResult(fmt.Errorf("delete_app: %w", err))
 		}
 		return jsonResult(map[string]any{"deleted": true, "name": p.Name})
 	})
@@ -78,13 +77,13 @@ func registerDestructiveTools(s *mcp.Server, client *truenas.Client) {
 		},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p deleteSnapshotInput) (*mcp.CallToolResult, any, error) {
 		if !p.Confirmed {
-			return nil, nil, errors.New("delete_snapshot: confirmed must be true to proceed with deletion")
+			return errorResult(errors.New("delete_snapshot: confirmed must be true to proceed with deletion"))
 		}
 		if p.ID == "" {
-			return nil, nil, errors.New("delete_snapshot: id must not be empty")
+			return errorResult(errors.New("delete_snapshot: id must not be empty"))
 		}
 		if err := client.DeleteSnapshot(ctx, p.ID); err != nil {
-			return nil, nil, fmt.Errorf("delete_snapshot: %w", err)
+			return errorResult(fmt.Errorf("delete_snapshot: %w", err))
 		}
 		return jsonResult(map[string]any{"deleted": true, "id": p.ID})
 	})
@@ -103,13 +102,13 @@ func registerDestructiveTools(s *mcp.Server, client *truenas.Client) {
 		},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p deleteVMDeviceInput) (*mcp.CallToolResult, any, error) {
 		if !p.Confirmed {
-			return nil, nil, errors.New("delete_vm_device: confirmed must be true to proceed with removal")
+			return errorResult(errors.New("delete_vm_device: confirmed must be true to proceed with removal"))
 		}
 		if p.ID <= 0 {
-			return nil, nil, errors.New("delete_vm_device: id must be a positive integer")
+			return errorResult(errors.New("delete_vm_device: id must be a positive integer"))
 		}
 		if err := client.DeleteVMDevice(ctx, p.ID); err != nil {
-			return nil, nil, fmt.Errorf("delete_vm_device: %w", err)
+			return errorResult(fmt.Errorf("delete_vm_device: %w", err))
 		}
 		return jsonResult(map[string]any{"deleted": true, "device_id": p.ID})
 	})
@@ -136,13 +135,13 @@ func registerDestructiveTools(s *mcp.Server, client *truenas.Client) {
 		},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p rollbackSnapshotInput) (*mcp.CallToolResult, any, error) {
 		if !p.Confirmed {
-			return nil, nil, errors.New("rollback_snapshot: confirmed must be true to proceed with rollback")
+			return errorResult(errors.New("rollback_snapshot: confirmed must be true to proceed with rollback"))
 		}
 		if p.ID == "" {
-			return nil, nil, errors.New("rollback_snapshot: id must not be empty")
+			return errorResult(errors.New("rollback_snapshot: id must not be empty"))
 		}
 		if p.RecursiveClones && !p.Recursive {
-			return nil, nil, errors.New("rollback_snapshot: recursive_clones requires recursive=true")
+			return errorResult(errors.New("rollback_snapshot: recursive_clones requires recursive=true"))
 		}
 		err := client.RollbackSnapshot(ctx, p.ID, truenas.RollbackSnapshotParams{
 			Recursive:       p.Recursive,
@@ -150,7 +149,7 @@ func registerDestructiveTools(s *mcp.Server, client *truenas.Client) {
 			Force:           p.Force,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("rollback_snapshot: %w", err)
+			return errorResult(fmt.Errorf("rollback_snapshot: %w", err))
 		}
 		return jsonResult(map[string]any{"rolled_back": true, "id": p.ID})
 	})

--- a/tools/destructive_test.go
+++ b/tools/destructive_test.go
@@ -1,0 +1,188 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+)
+
+func TestDeleteVM(t *testing.T) {
+	t.Run("succeeds with confirmed=true", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "delete_vm", map[string]any{"id": 1, "confirmed": true})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("requires confirmed=true", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "delete_vm", map[string]any{"id": 1, "confirmed": false})
+		assertError(t, res, "confirmed must be true")
+	})
+
+	t.Run("invalid id returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "delete_vm", map[string]any{"id": 0, "confirmed": true})
+		assertError(t, res, "id must be a positive integer")
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			deleteVMFn: func(_ context.Context, _ int) error {
+				return errors.New("VM is running")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "delete_vm", map[string]any{"id": 1, "confirmed": true})
+		assertError(t, res, "VM is running")
+	})
+}
+
+func TestDeleteApp(t *testing.T) {
+	t.Run("succeeds with confirmed=true", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "delete_app", map[string]any{"name": "jellyfin", "confirmed": true})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("requires confirmed=true", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "delete_app", map[string]any{"name": "jellyfin", "confirmed": false})
+		assertError(t, res, "confirmed must be true")
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "delete_app", map[string]any{"name": "", "confirmed": true})
+		assertError(t, res, "name must not be empty")
+	})
+}
+
+func TestDeleteSnapshot(t *testing.T) {
+	t.Run("succeeds with confirmed=true", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "delete_snapshot", map[string]any{
+			"id": "tank/data@snap1", "confirmed": true,
+		})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("requires confirmed=true", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "delete_snapshot", map[string]any{
+			"id": "tank/data@snap1", "confirmed": false,
+		})
+		assertError(t, res, "confirmed must be true")
+	})
+
+	t.Run("empty id returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "delete_snapshot", map[string]any{"id": "", "confirmed": true})
+		assertError(t, res, "id must not be empty")
+	})
+}
+
+func TestDeleteVMDevice(t *testing.T) {
+	t.Run("succeeds with confirmed=true", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "delete_vm_device", map[string]any{"id": 5, "confirmed": true})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("requires confirmed=true", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "delete_vm_device", map[string]any{"id": 5, "confirmed": false})
+		assertError(t, res, "confirmed must be true")
+	})
+
+	t.Run("invalid id returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "delete_vm_device", map[string]any{"id": 0, "confirmed": true})
+		assertError(t, res, "id must be a positive integer")
+	})
+}
+
+func TestRollbackSnapshot(t *testing.T) {
+	t.Run("succeeds with confirmed=true", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "rollback_snapshot", map[string]any{
+			"id": "tank/data@snap1", "confirmed": true,
+		})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("requires confirmed=true", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "rollback_snapshot", map[string]any{
+			"id": "tank/data@snap1", "confirmed": false,
+		})
+		assertError(t, res, "confirmed must be true")
+	})
+
+	t.Run("empty id returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "rollback_snapshot", map[string]any{"id": "", "confirmed": true})
+		assertError(t, res, "id must not be empty")
+	})
+
+	t.Run("recursive_clones without recursive returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "rollback_snapshot", map[string]any{
+			"id":               "tank/data@snap1",
+			"confirmed":        true,
+			"recursive_clones": true,
+			"recursive":        false,
+		})
+		assertError(t, res, "recursive_clones requires recursive=true")
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			rollbackSnapshotFn: func(_ context.Context, _ string, _ truenas.RollbackSnapshotParams) error {
+				return errors.New("dataset busy")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "rollback_snapshot", map[string]any{
+			"id": "tank/data@snap1", "confirmed": true,
+		})
+		assertError(t, res, "dataset busy")
+	})
+}

--- a/tools/filesystem.go
+++ b/tools/filesystem.go
@@ -6,12 +6,10 @@ import (
 	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-
-	"github.com/gordcurrie/truenas-mcp/internal/truenas"
 )
 
 // registerFilesystemTools registers filesystem-related MCP tools onto the server.
-func registerFilesystemTools(s *mcp.Server, client *truenas.Client) {
+func registerFilesystemTools(s *mcp.Server, client truenasClient) {
 	type listDirectoryInput struct {
 		// Path is the absolute path on the TrueNAS host to list, e.g. "/mnt/Storage/pbs".
 		Path string `json:"path" jsonschema:"Absolute path on the TrueNAS host filesystem, e.g. /mnt/Storage/pbs"`
@@ -23,11 +21,11 @@ func registerFilesystemTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p listDirectoryInput) (*mcp.CallToolResult, any, error) {
 		if p.Path == "" {
-			return nil, nil, errors.New("list_directory: path must not be empty")
+			return errorResult(errors.New("list_directory: path must not be empty"))
 		}
 		entries, err := client.ListDirectory(ctx, p.Path)
 		if err != nil {
-			return nil, nil, fmt.Errorf("list_directory: %w", err)
+			return errorResult(fmt.Errorf("list_directory: %w", err))
 		}
 		return jsonResult(entries)
 	})

--- a/tools/filesystem_test.go
+++ b/tools/filesystem_test.go
@@ -1,0 +1,45 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+)
+
+func TestListDirectory(t *testing.T) {
+	t.Run("returns entries as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listDirectoryFn: func(_ context.Context, _ string) ([]truenas.DirEntry, error) {
+				return []truenas.DirEntry{{Name: "pbs", Type: "DIRECTORY"}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_directory", map[string]any{"path": "/mnt/tank"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty path returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "list_directory", map[string]any{"path": ""})
+		assertError(t, res, "path must not be empty")
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listDirectoryFn: func(_ context.Context, _ string) ([]truenas.DirEntry, error) {
+				return nil, errors.New("path not found")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_directory", map[string]any{"path": "/mnt/noexist"})
+		assertError(t, res, "path not found")
+	})
+}

--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -20,3 +20,15 @@ func jsonResult(v any) (*mcp.CallToolResult, any, error) {
 		},
 	}, nil, nil
 }
+
+// errorResult returns an MCP-spec-compliant tool error result (isError: true).
+// Per MCP spec §6, tool execution errors should use isError rather than
+// propagating a protocol-level error.
+func errorResult(err error) (*mcp.CallToolResult, any, error) {
+	return &mcp.CallToolResult{
+		IsError: true,
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: err.Error()},
+		},
+	}, nil, nil
+}

--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -8,9 +8,9 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// jsonResult marshals v to indented JSON and returns it as a TextContent result.
+// jsonResult marshals v to compact JSON and returns it as a TextContent result.
 func jsonResult(v any) (*mcp.CallToolResult, any, error) {
-	data, err := json.MarshalIndent(v, "", "  ")
+	data, err := json.Marshal(v)
 	if err != nil {
 		return nil, nil, fmt.Errorf("marshalling result: %w", err)
 	}

--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -12,7 +12,7 @@ import (
 func jsonResult(v any) (*mcp.CallToolResult, any, error) {
 	data, err := json.Marshal(v)
 	if err != nil {
-		return nil, nil, fmt.Errorf("marshalling result: %w", err)
+		return errorResult(fmt.Errorf("marshalling result: %w", err))
 	}
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{

--- a/tools/helpers_test.go
+++ b/tools/helpers_test.go
@@ -52,10 +52,14 @@ func TestJsonResult_marshalError(t *testing.T) {
 	t.Parallel()
 
 	// Channels cannot be marshalled to JSON — exercises the error path.
+	// The marshal error is returned as an isError result, not a protocol error.
 	ch := make(chan int)
-	_, _, err := jsonResult(ch)
-	if err == nil {
-		t.Fatal("expected marshal error for channel type, got nil")
+	result, _, err := jsonResult(ch)
+	if err != nil {
+		t.Fatalf("expected no protocol error, got: %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatal("expected isError=true result for unmarshalable type")
 	}
 }
 

--- a/tools/helpers_test.go
+++ b/tools/helpers_test.go
@@ -1,25 +1,15 @@
 package tools
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func TestJsonResult_validInput(t *testing.T) {
-	t.Parallel()
-
-	result, _, err := jsonResult(map[string]string{"key": "value"})
-	if err != nil {
-		t.Fatalf("jsonResult: %v", err)
-	}
-	if len(result.Content) != 1 {
-		t.Fatalf("expected 1 content item, got %d", len(result.Content))
-	}
-}
-
-func TestJsonResult_containsJSON(t *testing.T) {
+func TestJsonResult_success(t *testing.T) {
 	t.Parallel()
 
 	type payload struct {
@@ -27,16 +17,72 @@ func TestJsonResult_containsJSON(t *testing.T) {
 		Age  int    `json:"age"`
 	}
 
-	result, _, err := jsonResult(payload{Name: "truenas", Age: 3})
+	result, extra, err := jsonResult(payload{Name: "truenas", Age: 3})
 	if err != nil {
-		t.Fatalf("jsonResult: %v", err)
+		t.Fatalf("jsonResult returned error: %v", err)
+	}
+	if extra != nil {
+		t.Errorf("expected nil extra, got %v", extra)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("expected 1 content item, got %d", len(result.Content))
+	}
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected *mcp.TextContent, got %T", result.Content[0])
 	}
 
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected *TextContent, got %T", result.Content[0])
+	var got payload
+	if err := json.Unmarshal([]byte(tc.Text), &got); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
 	}
-	if !strings.Contains(text.Text, "truenas") {
-		t.Errorf("output does not contain expected value: %s", text.Text)
+	if got.Name != "truenas" || got.Age != 3 {
+		t.Errorf("got %+v, want {Name:truenas Age:3}", got)
+	}
+	// Verify compact formatting — Marshal produces no newlines.
+	if strings.Contains(tc.Text, "\n") {
+		t.Errorf("expected compact JSON output (no newlines), got: %s", tc.Text)
+	}
+}
+
+func TestJsonResult_marshalError(t *testing.T) {
+	t.Parallel()
+
+	// Channels cannot be marshalled to JSON — exercises the error path.
+	ch := make(chan int)
+	_, _, err := jsonResult(ch)
+	if err == nil {
+		t.Fatal("expected marshal error for channel type, got nil")
+	}
+}
+
+func TestErrorResult(t *testing.T) {
+	t.Parallel()
+
+	result, extra, err := errorResult(fmt.Errorf("something went wrong: %w", fmt.Errorf("root cause")))
+	if err != nil {
+		t.Fatalf("errorResult returned protocol error: %v", err)
+	}
+	if extra != nil {
+		t.Errorf("expected nil extra, got %v", extra)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if !result.IsError {
+		t.Error("expected IsError=true")
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("expected 1 content item, got %d", len(result.Content))
+	}
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected *mcp.TextContent, got %T", result.Content[0])
+	}
+	if !strings.Contains(tc.Text, "something went wrong") {
+		t.Errorf("error text %q does not contain expected message", tc.Text)
 	}
 }

--- a/tools/mock_client_test.go
+++ b/tools/mock_client_test.go
@@ -1,0 +1,298 @@
+package tools
+
+import (
+	"context"
+
+	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+)
+
+// mockTruenasClient is a test double for truenasClient. Each method delegates to
+// the corresponding *Fn field if set; otherwise it returns zero values with no error.
+type mockTruenasClient struct {
+	getSystemInfoFn func(context.Context) (*truenas.SystemInfo, error)
+
+	listPoolsFn func(context.Context, ...truenas.ListOptions) ([]truenas.Pool, error)
+	getPoolFn   func(context.Context, int) (*truenas.Pool, error)
+
+	listDatasetsFn  func(context.Context, string, ...truenas.ListOptions) ([]truenas.Dataset, error)
+	getDatasetFn    func(context.Context, string) (*truenas.Dataset, error)
+	createDatasetFn func(context.Context, *truenas.CreateDatasetParams) (*truenas.Dataset, error)
+
+	listSnapshotsFn  func(context.Context, string, ...truenas.ListOptions) ([]truenas.Snapshot, error)
+	getSnapshotFn    func(context.Context, string) (*truenas.Snapshot, error)
+	createSnapshotFn func(context.Context, truenas.CreateSnapshotParams) (*truenas.Snapshot, error)
+	rollbackSnapshotFn func(context.Context, string, truenas.RollbackSnapshotParams) error
+	deleteSnapshotFn func(context.Context, string) error
+
+	listVMsFn      func(context.Context, ...truenas.ListOptions) ([]truenas.VM, error)
+	getVMFn        func(context.Context, int) (*truenas.VM, error)
+	startVMFn      func(context.Context, int) (int, error)
+	stopVMFn       func(context.Context, int, bool) (int, error)
+	restartVMFn    func(context.Context, int) (int, error)
+	createVMFn     func(context.Context, *truenas.CreateVMParams) (*truenas.VM, error)
+	updateVMFn     func(context.Context, int, *truenas.UpdateVMParams) (*truenas.VM, error)
+	deleteVMFn     func(context.Context, int) error
+	listVMDevicesFn func(context.Context, int) ([]truenas.VMDevice, error)
+	addVMDeviceFn  func(context.Context, *truenas.AddVMDeviceParams) (*truenas.VMDevice, error)
+	deleteVMDeviceFn func(context.Context, int) error
+
+	listAppsFn       func(context.Context, ...truenas.ListOptions) ([]truenas.App, error)
+	getAppFn         func(context.Context, string) (*truenas.App, error)
+	startAppFn       func(context.Context, string) (int, error)
+	stopAppFn        func(context.Context, string) (int, error)
+	restartAppFn     func(context.Context, string) (int, error)
+	listImagesFn     func(context.Context) ([]truenas.Image, error)
+	createAppFn      func(context.Context, *truenas.CreateAppParams) (int, error)
+	deleteAppFn      func(context.Context, string) error
+	upgradeAppFn     func(context.Context, string, string) (int, error)
+	getUpgradeSummaryFn func(context.Context, string) (*truenas.AppUpgradeSummary, error)
+	rollbackAppFn    func(context.Context, string, string) (int, error)
+
+	listInterfacesFn func(context.Context) ([]truenas.Interface, error)
+	listDirectoryFn  func(context.Context, string) ([]truenas.DirEntry, error)
+}
+
+func (m *mockTruenasClient) GetSystemInfo(ctx context.Context) (*truenas.SystemInfo, error) {
+	if m.getSystemInfoFn != nil {
+		return m.getSystemInfoFn(ctx)
+	}
+	return &truenas.SystemInfo{}, nil
+}
+
+func (m *mockTruenasClient) ListPools(ctx context.Context, opts ...truenas.ListOptions) ([]truenas.Pool, error) {
+	if m.listPoolsFn != nil {
+		return m.listPoolsFn(ctx, opts...)
+	}
+	return nil, nil
+}
+
+func (m *mockTruenasClient) GetPool(ctx context.Context, id int) (*truenas.Pool, error) {
+	if m.getPoolFn != nil {
+		return m.getPoolFn(ctx, id)
+	}
+	return &truenas.Pool{}, nil
+}
+
+func (m *mockTruenasClient) ListDatasets(ctx context.Context, pool string, opts ...truenas.ListOptions) ([]truenas.Dataset, error) {
+	if m.listDatasetsFn != nil {
+		return m.listDatasetsFn(ctx, pool, opts...)
+	}
+	return nil, nil
+}
+
+func (m *mockTruenasClient) GetDataset(ctx context.Context, id string) (*truenas.Dataset, error) {
+	if m.getDatasetFn != nil {
+		return m.getDatasetFn(ctx, id)
+	}
+	return &truenas.Dataset{}, nil
+}
+
+func (m *mockTruenasClient) CreateDataset(ctx context.Context, params *truenas.CreateDatasetParams) (*truenas.Dataset, error) {
+	if m.createDatasetFn != nil {
+		return m.createDatasetFn(ctx, params)
+	}
+	return &truenas.Dataset{}, nil
+}
+
+func (m *mockTruenasClient) ListSnapshots(ctx context.Context, dataset string, opts ...truenas.ListOptions) ([]truenas.Snapshot, error) {
+	if m.listSnapshotsFn != nil {
+		return m.listSnapshotsFn(ctx, dataset, opts...)
+	}
+	return nil, nil
+}
+
+func (m *mockTruenasClient) GetSnapshot(ctx context.Context, id string) (*truenas.Snapshot, error) {
+	if m.getSnapshotFn != nil {
+		return m.getSnapshotFn(ctx, id)
+	}
+	return &truenas.Snapshot{}, nil
+}
+
+func (m *mockTruenasClient) CreateSnapshot(ctx context.Context, params truenas.CreateSnapshotParams) (*truenas.Snapshot, error) {
+	if m.createSnapshotFn != nil {
+		return m.createSnapshotFn(ctx, params)
+	}
+	return &truenas.Snapshot{}, nil
+}
+
+func (m *mockTruenasClient) RollbackSnapshot(ctx context.Context, id string, params truenas.RollbackSnapshotParams) error {
+	if m.rollbackSnapshotFn != nil {
+		return m.rollbackSnapshotFn(ctx, id, params)
+	}
+	return nil
+}
+
+func (m *mockTruenasClient) DeleteSnapshot(ctx context.Context, id string) error {
+	if m.deleteSnapshotFn != nil {
+		return m.deleteSnapshotFn(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockTruenasClient) ListVMs(ctx context.Context, opts ...truenas.ListOptions) ([]truenas.VM, error) {
+	if m.listVMsFn != nil {
+		return m.listVMsFn(ctx, opts...)
+	}
+	return nil, nil
+}
+
+func (m *mockTruenasClient) GetVM(ctx context.Context, id int) (*truenas.VM, error) {
+	if m.getVMFn != nil {
+		return m.getVMFn(ctx, id)
+	}
+	return &truenas.VM{}, nil
+}
+
+func (m *mockTruenasClient) StartVM(ctx context.Context, id int) (int, error) {
+	if m.startVMFn != nil {
+		return m.startVMFn(ctx, id)
+	}
+	return 0, nil
+}
+
+func (m *mockTruenasClient) StopVM(ctx context.Context, id int, force bool) (int, error) {
+	if m.stopVMFn != nil {
+		return m.stopVMFn(ctx, id, force)
+	}
+	return 0, nil
+}
+
+func (m *mockTruenasClient) RestartVM(ctx context.Context, id int) (int, error) {
+	if m.restartVMFn != nil {
+		return m.restartVMFn(ctx, id)
+	}
+	return 0, nil
+}
+
+func (m *mockTruenasClient) CreateVM(ctx context.Context, params *truenas.CreateVMParams) (*truenas.VM, error) {
+	if m.createVMFn != nil {
+		return m.createVMFn(ctx, params)
+	}
+	return &truenas.VM{}, nil
+}
+
+func (m *mockTruenasClient) UpdateVM(ctx context.Context, id int, params *truenas.UpdateVMParams) (*truenas.VM, error) {
+	if m.updateVMFn != nil {
+		return m.updateVMFn(ctx, id, params)
+	}
+	return &truenas.VM{}, nil
+}
+
+func (m *mockTruenasClient) DeleteVM(ctx context.Context, id int) error {
+	if m.deleteVMFn != nil {
+		return m.deleteVMFn(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockTruenasClient) ListVMDevices(ctx context.Context, vmID int) ([]truenas.VMDevice, error) {
+	if m.listVMDevicesFn != nil {
+		return m.listVMDevicesFn(ctx, vmID)
+	}
+	return nil, nil
+}
+
+func (m *mockTruenasClient) AddVMDevice(ctx context.Context, params *truenas.AddVMDeviceParams) (*truenas.VMDevice, error) {
+	if m.addVMDeviceFn != nil {
+		return m.addVMDeviceFn(ctx, params)
+	}
+	return &truenas.VMDevice{}, nil
+}
+
+func (m *mockTruenasClient) DeleteVMDevice(ctx context.Context, deviceID int) error {
+	if m.deleteVMDeviceFn != nil {
+		return m.deleteVMDeviceFn(ctx, deviceID)
+	}
+	return nil
+}
+
+func (m *mockTruenasClient) ListApps(ctx context.Context, opts ...truenas.ListOptions) ([]truenas.App, error) {
+	if m.listAppsFn != nil {
+		return m.listAppsFn(ctx, opts...)
+	}
+	return nil, nil
+}
+
+func (m *mockTruenasClient) GetApp(ctx context.Context, name string) (*truenas.App, error) {
+	if m.getAppFn != nil {
+		return m.getAppFn(ctx, name)
+	}
+	return &truenas.App{}, nil
+}
+
+func (m *mockTruenasClient) StartApp(ctx context.Context, name string) (int, error) {
+	if m.startAppFn != nil {
+		return m.startAppFn(ctx, name)
+	}
+	return 0, nil
+}
+
+func (m *mockTruenasClient) StopApp(ctx context.Context, name string) (int, error) {
+	if m.stopAppFn != nil {
+		return m.stopAppFn(ctx, name)
+	}
+	return 0, nil
+}
+
+func (m *mockTruenasClient) RestartApp(ctx context.Context, name string) (int, error) {
+	if m.restartAppFn != nil {
+		return m.restartAppFn(ctx, name)
+	}
+	return 0, nil
+}
+
+func (m *mockTruenasClient) ListImages(ctx context.Context) ([]truenas.Image, error) {
+	if m.listImagesFn != nil {
+		return m.listImagesFn(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockTruenasClient) CreateApp(ctx context.Context, params *truenas.CreateAppParams) (int, error) {
+	if m.createAppFn != nil {
+		return m.createAppFn(ctx, params)
+	}
+	return 0, nil
+}
+
+func (m *mockTruenasClient) DeleteApp(ctx context.Context, name string) error {
+	if m.deleteAppFn != nil {
+		return m.deleteAppFn(ctx, name)
+	}
+	return nil
+}
+
+func (m *mockTruenasClient) UpgradeApp(ctx context.Context, name, version string) (int, error) {
+	if m.upgradeAppFn != nil {
+		return m.upgradeAppFn(ctx, name, version)
+	}
+	return 0, nil
+}
+
+func (m *mockTruenasClient) GetUpgradeSummary(ctx context.Context, name string) (*truenas.AppUpgradeSummary, error) {
+	if m.getUpgradeSummaryFn != nil {
+		return m.getUpgradeSummaryFn(ctx, name)
+	}
+	return &truenas.AppUpgradeSummary{}, nil
+}
+
+func (m *mockTruenasClient) RollbackApp(ctx context.Context, name, version string) (int, error) {
+	if m.rollbackAppFn != nil {
+		return m.rollbackAppFn(ctx, name, version)
+	}
+	return 0, nil
+}
+
+func (m *mockTruenasClient) ListInterfaces(ctx context.Context) ([]truenas.Interface, error) {
+	if m.listInterfacesFn != nil {
+		return m.listInterfacesFn(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockTruenasClient) ListDirectory(ctx context.Context, path string) ([]truenas.DirEntry, error) {
+	if m.listDirectoryFn != nil {
+		return m.listDirectoryFn(ctx, path)
+	}
+	return nil, nil
+}

--- a/tools/network.go
+++ b/tools/network.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-
-	"github.com/gordcurrie/truenas-mcp/internal/truenas"
 )
 
 // registerNetworkTools registers network-related MCP tools onto the server.
-func registerNetworkTools(s *mcp.Server, client *truenas.Client) {
+func registerNetworkTools(s *mcp.Server, client truenasClient) {
 	type listInterfacesInput struct{}
 
 	mcp.AddTool(s, &mcp.Tool{
@@ -20,7 +18,7 @@ func registerNetworkTools(s *mcp.Server, client *truenas.Client) {
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ listInterfacesInput) (*mcp.CallToolResult, any, error) {
 		ifaces, err := client.ListInterfaces(ctx)
 		if err != nil {
-			return nil, nil, fmt.Errorf("list_interfaces: %w", err)
+			return errorResult(fmt.Errorf("list_interfaces: %w", err))
 		}
 		return jsonResult(ifaces)
 	})

--- a/tools/network_test.go
+++ b/tools/network_test.go
@@ -1,0 +1,37 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+)
+
+func TestListInterfaces(t *testing.T) {
+	t.Run("returns interfaces as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listInterfacesFn: func(_ context.Context) ([]truenas.Interface, error) {
+				return []truenas.Interface{{Name: "eth0"}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_interfaces", nil)
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listInterfacesFn: func(_ context.Context) ([]truenas.Interface, error) {
+				return nil, errors.New("API error")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_interfaces", nil)
+		assertError(t, res, "API error")
+	})
+}

--- a/tools/pool.go
+++ b/tools/pool.go
@@ -5,13 +5,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // registerPoolTools registers all pool-related MCP tools onto the server.
-func registerPoolTools(s *mcp.Server, client *truenas.Client) {
+func registerPoolTools(s *mcp.Server, client truenasClient) {
 	type listPoolsInput struct {
 		Limit  int `json:"limit,omitempty"  jsonschema:"Maximum number of pools to return; 0 means no limit"`
 		Offset int `json:"offset,omitempty" jsonschema:"Number of pools to skip; 0 means start from the beginning"`
@@ -24,7 +23,7 @@ func registerPoolTools(s *mcp.Server, client *truenas.Client) {
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p listPoolsInput) (*mcp.CallToolResult, any, error) {
 		pools, err := client.ListPools(ctx, truenas.ListOptions{Limit: p.Limit, Offset: p.Offset})
 		if err != nil {
-			return nil, nil, fmt.Errorf("list_pools: %w", err)
+			return errorResult(fmt.Errorf("list_pools: %w", err))
 		}
 		return jsonResult(pools)
 	})
@@ -39,14 +38,14 @@ func registerPoolTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p getPoolInput) (*mcp.CallToolResult, any, error) {
 		if p.ID <= 0 {
-			return nil, nil, errors.New("get_pool: id must be a positive integer")
+			return errorResult(errors.New("get_pool: id must be a positive integer"))
 		}
 		pool, err := client.GetPool(ctx, p.ID)
 		if err != nil {
 			if errors.Is(err, truenas.ErrNotFound) {
-				return nil, nil, fmt.Errorf("get_pool: pool %d not found", p.ID)
+				return errorResult(fmt.Errorf("get_pool: pool %d not found", p.ID))
 			}
-			return nil, nil, fmt.Errorf("get_pool: %w", err)
+			return errorResult(fmt.Errorf("get_pool: %w", err))
 		}
 		return jsonResult(pool)
 	})

--- a/tools/pool_test.go
+++ b/tools/pool_test.go
@@ -1,0 +1,73 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+)
+
+func TestListPools(t *testing.T) {
+	t.Run("returns pools as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listPoolsFn: func(_ context.Context, _ ...truenas.ListOptions) ([]truenas.Pool, error) {
+				return []truenas.Pool{{ID: 1, Name: "tank"}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_pools", nil)
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listPoolsFn: func(_ context.Context, _ ...truenas.ListOptions) ([]truenas.Pool, error) {
+				return nil, errors.New("API error")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_pools", nil)
+		assertError(t, res, "API error")
+	})
+}
+
+func TestGetPool(t *testing.T) {
+	t.Run("returns pool as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			getPoolFn: func(_ context.Context, id int) (*truenas.Pool, error) {
+				return &truenas.Pool{ID: id, Name: "tank"}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_pool", map[string]any{"id": 1})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("invalid id returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "get_pool", map[string]any{"id": 0})
+		assertError(t, res, "id must be a positive integer")
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			getPoolFn: func(_ context.Context, _ int) (*truenas.Pool, error) {
+				return nil, errors.New("pool not found")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_pool", map[string]any{"id": 99})
+		assertError(t, res, "pool not found")
+	})
+}

--- a/tools/register.go
+++ b/tools/register.go
@@ -2,7 +2,6 @@
 package tools
 
 import (
-	"github.com/gordcurrie/truenas-mcp/internal/truenas"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -13,7 +12,7 @@ type Config struct {
 }
 
 // RegisterAll wires all TrueNAS MCP tools onto the provided server.
-func RegisterAll(s *mcp.Server, client *truenas.Client, cfg Config) {
+func RegisterAll(s *mcp.Server, client truenasClient, cfg Config) {
 	registerSystemTools(s, client)
 	registerNetworkTools(s, client)
 	registerFilesystemTools(s, client)

--- a/tools/snapshot.go
+++ b/tools/snapshot.go
@@ -5,13 +5,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // registerSnapshotTools registers all ZFS snapshot-related MCP tools onto the server.
-func registerSnapshotTools(s *mcp.Server, client *truenas.Client) {
+func registerSnapshotTools(s *mcp.Server, client truenasClient) {
 	type listSnapshotsInput struct {
 		// Dataset filters results to snapshots of this dataset (e.g. "Storage/backups").
 		// Leave empty to return snapshots from all datasets.
@@ -27,7 +26,7 @@ func registerSnapshotTools(s *mcp.Server, client *truenas.Client) {
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p listSnapshotsInput) (*mcp.CallToolResult, any, error) {
 		snaps, err := client.ListSnapshots(ctx, p.Dataset, truenas.ListOptions{Limit: p.Limit, Offset: p.Offset})
 		if err != nil {
-			return nil, nil, fmt.Errorf("list_snapshots: %w", err)
+			return errorResult(fmt.Errorf("list_snapshots: %w", err))
 		}
 		return jsonResult(snaps)
 	})
@@ -44,14 +43,14 @@ func registerSnapshotTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p getSnapshotInput) (*mcp.CallToolResult, any, error) {
 		if p.ID == "" {
-			return nil, nil, errors.New("get_snapshot: id must not be empty")
+			return errorResult(errors.New("get_snapshot: id must not be empty"))
 		}
 		snap, err := client.GetSnapshot(ctx, p.ID)
 		if err != nil {
 			if errors.Is(err, truenas.ErrNotFound) {
-				return nil, nil, fmt.Errorf("get_snapshot: snapshot %q not found", p.ID)
+				return errorResult(fmt.Errorf("get_snapshot: snapshot %q not found", p.ID))
 			}
-			return nil, nil, fmt.Errorf("get_snapshot: %w", err)
+			return errorResult(fmt.Errorf("get_snapshot: %w", err))
 		}
 		return jsonResult(snap)
 	})
@@ -71,10 +70,10 @@ func registerSnapshotTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p createSnapshotInput) (*mcp.CallToolResult, any, error) {
 		if p.Dataset == "" {
-			return nil, nil, errors.New("create_snapshot: dataset must not be empty")
+			return errorResult(errors.New("create_snapshot: dataset must not be empty"))
 		}
 		if p.Name == "" {
-			return nil, nil, errors.New("create_snapshot: name must not be empty")
+			return errorResult(errors.New("create_snapshot: name must not be empty"))
 		}
 		snap, err := client.CreateSnapshot(ctx, truenas.CreateSnapshotParams{
 			Dataset:   p.Dataset,
@@ -82,7 +81,7 @@ func registerSnapshotTools(s *mcp.Server, client *truenas.Client) {
 			Recursive: p.Recursive,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("create_snapshot: %w", err)
+			return errorResult(fmt.Errorf("create_snapshot: %w", err))
 		}
 		return jsonResult(snap)
 	})

--- a/tools/snapshot_test.go
+++ b/tools/snapshot_test.go
@@ -1,0 +1,120 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+)
+
+func TestListSnapshots(t *testing.T) {
+	t.Run("returns snapshots as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listSnapshotsFn: func(_ context.Context, _ string, _ ...truenas.ListOptions) ([]truenas.Snapshot, error) {
+				return []truenas.Snapshot{{ID: "tank/data@snap1"}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_snapshots", nil)
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listSnapshotsFn: func(_ context.Context, _ string, _ ...truenas.ListOptions) ([]truenas.Snapshot, error) {
+				return nil, errors.New("API error")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_snapshots", nil)
+		assertError(t, res, "API error")
+	})
+}
+
+func TestGetSnapshot(t *testing.T) {
+	t.Run("returns snapshot as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			getSnapshotFn: func(_ context.Context, id string) (*truenas.Snapshot, error) {
+				return &truenas.Snapshot{ID: id}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_snapshot", map[string]any{"id": "tank/data@snap1"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty id returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "get_snapshot", map[string]any{"id": ""})
+		assertError(t, res, "id must not be empty")
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			getSnapshotFn: func(_ context.Context, _ string) (*truenas.Snapshot, error) {
+				return nil, errors.New("snapshot not found")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_snapshot", map[string]any{"id": "tank/data@noexist"})
+		assertError(t, res, "snapshot not found")
+	})
+}
+
+func TestCreateSnapshot(t *testing.T) {
+	t.Run("returns created snapshot as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			createSnapshotFn: func(_ context.Context, p truenas.CreateSnapshotParams) (*truenas.Snapshot, error) {
+				return &truenas.Snapshot{ID: p.Dataset + "@" + p.Name}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "create_snapshot", map[string]any{
+			"dataset": "tank/data",
+			"name":    "before-upgrade",
+		})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty dataset returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "create_snapshot", map[string]any{"dataset": "", "name": "snap1"})
+		assertError(t, res, "dataset must not be empty")
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "create_snapshot", map[string]any{"dataset": "tank/data", "name": ""})
+		assertError(t, res, "name must not be empty")
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			createSnapshotFn: func(_ context.Context, _ truenas.CreateSnapshotParams) (*truenas.Snapshot, error) {
+				return nil, errors.New("dataset busy")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "create_snapshot", map[string]any{"dataset": "tank/data", "name": "snap1"})
+		assertError(t, res, "dataset busy")
+	})
+}

--- a/tools/system.go
+++ b/tools/system.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gordcurrie/truenas-mcp/internal/truenas"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // registerSystemTools adds system info MCP tools to the server.
-func registerSystemTools(s *mcp.Server, client *truenas.Client) {
+func registerSystemTools(s *mcp.Server, client truenasClient) {
 	type getSystemInfoInput struct{}
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "get_system_info",
@@ -18,7 +17,7 @@ func registerSystemTools(s *mcp.Server, client *truenas.Client) {
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ getSystemInfoInput) (*mcp.CallToolResult, any, error) {
 		info, err := client.GetSystemInfo(ctx)
 		if err != nil {
-			return nil, nil, fmt.Errorf("get_system_info: %w", err)
+			return errorResult(fmt.Errorf("get_system_info: %w", err))
 		}
 		return jsonResult(info)
 	})

--- a/tools/system_test.go
+++ b/tools/system_test.go
@@ -1,0 +1,37 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+)
+
+func TestGetSystemInfo(t *testing.T) {
+	t.Run("returns system info as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			getSystemInfoFn: func(context.Context) (*truenas.SystemInfo, error) {
+				return &truenas.SystemInfo{Hostname: "truenas", Version: "TrueNAS-SCALE-24.04"}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_system_info", nil)
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			getSystemInfoFn: func(context.Context) (*truenas.SystemInfo, error) {
+				return nil, errors.New("connection refused")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_system_info", nil)
+		assertError(t, res, "connection refused")
+	})
+}

--- a/tools/tooltest_test.go
+++ b/tools/tooltest_test.go
@@ -1,0 +1,109 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// connectTestServer registers all tools on a new MCP server backed by the
+// provided mock, then returns a connected client session. The cleanup function
+// closes the session and must be deferred by the caller.
+func connectTestServer(t *testing.T, mock *mockTruenasClient) (session *mcp.ClientSession, cleanup func()) {
+	t.Helper()
+
+	s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "v0.0.1"}, nil)
+	RegisterAll(s, mock, Config{AllowDestructive: true})
+
+	ct, st := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+
+	if _, err := s.Connect(ctx, st, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+
+	c := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	cs, err := c.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+
+	return cs, func() {
+		if err := cs.Close(); err != nil {
+			t.Logf("client session close: %v", err)
+		}
+	}
+}
+
+// callTool is a test shorthand that calls the named tool and returns the result.
+func callTool(t *testing.T, cs *mcp.ClientSession, name string, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	ctx := context.Background()
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: args})
+	if err != nil {
+		t.Fatalf("CallTool %s: %v", name, err)
+	}
+	return res
+}
+
+// assertSuccess fails the test if result has IsError set.
+func assertSuccess(t *testing.T, res *mcp.CallToolResult) {
+	t.Helper()
+	if res.IsError {
+		var text string
+		if len(res.Content) > 0 {
+			if tc, ok := res.Content[0].(*mcp.TextContent); ok {
+				text = tc.Text
+			}
+		}
+		t.Errorf("expected success, got isError=true: %s", text)
+	}
+}
+
+// assertError fails the test if result does not have IsError set, or if the
+// error message does not contain the expected substring.
+func assertError(t *testing.T, res *mcp.CallToolResult, wantContains string) {
+	t.Helper()
+	if !res.IsError {
+		t.Errorf("expected isError=true, got success")
+		return
+	}
+	if wantContains == "" {
+		return
+	}
+	if len(res.Content) == 0 {
+		t.Errorf("expected error content, got none")
+		return
+	}
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Errorf("expected TextContent, got %T", res.Content[0])
+		return
+	}
+	if !strings.Contains(tc.Text, wantContains) {
+		t.Errorf("error text %q does not contain %q", tc.Text, wantContains)
+	}
+}
+
+// assertResultJSON fails the test if result has IsError set, has no content,
+// or if the content is not valid non-empty JSON.
+func assertResultJSON(t *testing.T, res *mcp.CallToolResult) {
+	t.Helper()
+	assertSuccess(t, res)
+	if len(res.Content) == 0 {
+		t.Fatalf("expected content, got none")
+	}
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", res.Content[0])
+	}
+	if tc.Text == "" {
+		t.Fatal("expected non-empty content text")
+	}
+	if !json.Valid([]byte(tc.Text)) {
+		t.Fatalf("content is not valid JSON: %q", tc.Text)
+	}
+}

--- a/tools/vm.go
+++ b/tools/vm.go
@@ -5,13 +5,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // registerVMTools registers all VM-related MCP tools onto the server.
-func registerVMTools(s *mcp.Server, client *truenas.Client) {
+func registerVMTools(s *mcp.Server, client truenasClient) {
 	type listVMsInput struct {
 		Limit  int `json:"limit,omitempty"  jsonschema:"Maximum number of VMs to return; 0 means no limit"`
 		Offset int `json:"offset,omitempty" jsonschema:"Number of VMs to skip; 0 means start from the beginning"`
@@ -24,7 +23,7 @@ func registerVMTools(s *mcp.Server, client *truenas.Client) {
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p listVMsInput) (*mcp.CallToolResult, any, error) {
 		vms, err := client.ListVMs(ctx, truenas.ListOptions{Limit: p.Limit, Offset: p.Offset})
 		if err != nil {
-			return nil, nil, fmt.Errorf("list_vms: %w", err)
+			return errorResult(fmt.Errorf("list_vms: %w", err))
 		}
 		return jsonResult(vms)
 	})
@@ -39,14 +38,14 @@ func registerVMTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p getVMInput) (*mcp.CallToolResult, any, error) {
 		if p.ID <= 0 {
-			return nil, nil, errors.New("get_vm: id must be a positive integer")
+			return errorResult(errors.New("get_vm: id must be a positive integer"))
 		}
 		vm, err := client.GetVM(ctx, p.ID)
 		if err != nil {
 			if errors.Is(err, truenas.ErrNotFound) {
-				return nil, nil, fmt.Errorf("get_vm: VM %d not found", p.ID)
+				return errorResult(fmt.Errorf("get_vm: VM %d not found", p.ID))
 			}
-			return nil, nil, fmt.Errorf("get_vm: %w", err)
+			return errorResult(fmt.Errorf("get_vm: %w", err))
 		}
 		return jsonResult(vm)
 	})
@@ -61,11 +60,11 @@ func registerVMTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p startVMInput) (*mcp.CallToolResult, any, error) {
 		if p.ID <= 0 {
-			return nil, nil, errors.New("start_vm: id must be a positive integer")
+			return errorResult(errors.New("start_vm: id must be a positive integer"))
 		}
 		jobID, err := client.StartVM(ctx, p.ID)
 		if err != nil {
-			return nil, nil, fmt.Errorf("start_vm: %w", err)
+			return errorResult(fmt.Errorf("start_vm: %w", err))
 		}
 		return jsonResult(map[string]int{"job_id": jobID})
 	})
@@ -81,11 +80,11 @@ func registerVMTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p stopVMInput) (*mcp.CallToolResult, any, error) {
 		if p.ID <= 0 {
-			return nil, nil, errors.New("stop_vm: id must be a positive integer")
+			return errorResult(errors.New("stop_vm: id must be a positive integer"))
 		}
 		jobID, err := client.StopVM(ctx, p.ID, p.Force)
 		if err != nil {
-			return nil, nil, fmt.Errorf("stop_vm: %w", err)
+			return errorResult(fmt.Errorf("stop_vm: %w", err))
 		}
 		return jsonResult(map[string]int{"job_id": jobID})
 	})
@@ -100,11 +99,11 @@ func registerVMTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p restartVMInput) (*mcp.CallToolResult, any, error) {
 		if p.ID <= 0 {
-			return nil, nil, errors.New("restart_vm: id must be a positive integer")
+			return errorResult(errors.New("restart_vm: id must be a positive integer"))
 		}
 		jobID, err := client.RestartVM(ctx, p.ID)
 		if err != nil {
-			return nil, nil, fmt.Errorf("restart_vm: %w", err)
+			return errorResult(fmt.Errorf("restart_vm: %w", err))
 		}
 		return jsonResult(map[string]int{"job_id": jobID})
 	})
@@ -129,10 +128,10 @@ func registerVMTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p createVMInput) (*mcp.CallToolResult, any, error) {
 		if p.Name == "" {
-			return nil, nil, errors.New("create_vm: name must not be empty")
+			return errorResult(errors.New("create_vm: name must not be empty"))
 		}
 		if p.Memory <= 0 {
-			return nil, nil, errors.New("create_vm: memory must be greater than 0")
+			return errorResult(errors.New("create_vm: memory must be greater than 0"))
 		}
 		vm, err := client.CreateVM(ctx, &truenas.CreateVMParams{
 			Name:            p.Name,
@@ -148,7 +147,7 @@ func registerVMTools(s *mcp.Server, client *truenas.Client) {
 			CPUModel:        p.CPUModel,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("create_vm: %w", err)
+			return errorResult(fmt.Errorf("create_vm: %w", err))
 		}
 		return jsonResult(vm)
 	})
@@ -173,7 +172,7 @@ func registerVMTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p updateVMInput) (*mcp.CallToolResult, any, error) {
 		if p.ID <= 0 {
-			return nil, nil, errors.New("update_vm: id must be a positive integer")
+			return errorResult(errors.New("update_vm: id must be a positive integer"))
 		}
 		vm, err := client.UpdateVM(ctx, p.ID, &truenas.UpdateVMParams{
 			Name:            p.Name,
@@ -188,7 +187,7 @@ func registerVMTools(s *mcp.Server, client *truenas.Client) {
 			CPUModel:        p.CPUModel,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("update_vm: %w", err)
+			return errorResult(fmt.Errorf("update_vm: %w", err))
 		}
 		return jsonResult(vm)
 	})
@@ -203,11 +202,11 @@ func registerVMTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p listVMDevicesInput) (*mcp.CallToolResult, any, error) {
 		if p.ID <= 0 {
-			return nil, nil, errors.New("list_vm_devices: id must be a positive integer")
+			return errorResult(errors.New("list_vm_devices: id must be a positive integer"))
 		}
 		devices, err := client.ListVMDevices(ctx, p.ID)
 		if err != nil {
-			return nil, nil, fmt.Errorf("list_vm_devices: %w", err)
+			return errorResult(fmt.Errorf("list_vm_devices: %w", err))
 		}
 		return jsonResult(devices)
 	})
@@ -225,13 +224,13 @@ func registerVMTools(s *mcp.Server, client *truenas.Client) {
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, p addVMDeviceInput) (*mcp.CallToolResult, any, error) {
 		if p.VMID <= 0 {
-			return nil, nil, errors.New("add_vm_device: vm_id must be a positive integer")
+			return errorResult(errors.New("add_vm_device: vm_id must be a positive integer"))
 		}
 		switch truenas.VMDeviceType(p.DType) {
 		case truenas.VMDeviceTypeDISK, truenas.VMDeviceTypeCDROM, truenas.VMDeviceTypeNIC, truenas.VMDeviceTypeDISPLAY, truenas.VMDeviceTypeRAW:
 			// valid dtype
 		default:
-			return nil, nil, fmt.Errorf("add_vm_device: dtype must be one of DISK, CDROM, NIC, DISPLAY, RAW; got %q", p.DType)
+			return errorResult(fmt.Errorf("add_vm_device: dtype must be one of DISK, CDROM, NIC, DISPLAY, RAW; got %q", p.DType))
 		}
 		device, err := client.AddVMDevice(ctx, &truenas.AddVMDeviceParams{
 			VMID:       p.VMID,
@@ -240,7 +239,7 @@ func registerVMTools(s *mcp.Server, client *truenas.Client) {
 			Order:      p.Order,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("add_vm_device: %w", err)
+			return errorResult(fmt.Errorf("add_vm_device: %w", err))
 		}
 		return jsonResult(device)
 	})

--- a/tools/vm_test.go
+++ b/tools/vm_test.go
@@ -1,0 +1,275 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gordcurrie/truenas-mcp/internal/truenas"
+)
+
+func TestListVMs(t *testing.T) {
+	t.Run("returns VMs as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listVMsFn: func(_ context.Context, _ ...truenas.ListOptions) ([]truenas.VM, error) {
+				return []truenas.VM{{ID: 1, Name: "pbs"}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_vms", nil)
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listVMsFn: func(_ context.Context, _ ...truenas.ListOptions) ([]truenas.VM, error) {
+				return nil, errors.New("API error")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_vms", nil)
+		assertError(t, res, "API error")
+	})
+}
+
+func TestGetVM(t *testing.T) {
+	t.Run("returns VM as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			getVMFn: func(_ context.Context, id int) (*truenas.VM, error) {
+				return &truenas.VM{ID: id, Name: "pbs"}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_vm", map[string]any{"id": 1})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("invalid id returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "get_vm", map[string]any{"id": 0})
+		assertError(t, res, "id must be a positive integer")
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			getVMFn: func(_ context.Context, _ int) (*truenas.VM, error) {
+				return nil, errors.New("VM not found")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_vm", map[string]any{"id": 99})
+		assertError(t, res, "VM not found")
+	})
+}
+
+func TestStartVM(t *testing.T) {
+	t.Run("returns job ID as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			startVMFn: func(_ context.Context, _ int) (int, error) {
+				return 42, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "start_vm", map[string]any{"id": 1})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("invalid id returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "start_vm", map[string]any{"id": 0})
+		assertError(t, res, "id must be a positive integer")
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			startVMFn: func(_ context.Context, _ int) (int, error) {
+				return 0, errors.New("VM already running")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "start_vm", map[string]any{"id": 1})
+		assertError(t, res, "VM already running")
+	})
+}
+
+func TestStopVM(t *testing.T) {
+	t.Run("returns job ID as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			stopVMFn: func(_ context.Context, _ int, _ bool) (int, error) {
+				return 43, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "stop_vm", map[string]any{"id": 1})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("invalid id returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "stop_vm", map[string]any{"id": -1})
+		assertError(t, res, "id must be a positive integer")
+	})
+}
+
+func TestRestartVM(t *testing.T) {
+	t.Run("returns job ID as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			restartVMFn: func(_ context.Context, _ int) (int, error) {
+				return 44, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "restart_vm", map[string]any{"id": 1})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("invalid id returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "restart_vm", map[string]any{"id": 0})
+		assertError(t, res, "id must be a positive integer")
+	})
+}
+
+func TestCreateVM(t *testing.T) {
+	t.Run("returns created VM as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			createVMFn: func(_ context.Context, p *truenas.CreateVMParams) (*truenas.VM, error) {
+				return &truenas.VM{ID: 1, Name: p.Name}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "create_vm", map[string]any{"name": "pbs", "memory": 4096})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "create_vm", map[string]any{"name": "", "memory": 4096})
+		assertError(t, res, "name must not be empty")
+	})
+
+	t.Run("zero memory returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "create_vm", map[string]any{"name": "pbs", "memory": 0})
+		assertError(t, res, "memory must be greater than 0")
+	})
+}
+
+func TestUpdateVM(t *testing.T) {
+	t.Run("returns updated VM as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			updateVMFn: func(_ context.Context, id int, _ *truenas.UpdateVMParams) (*truenas.VM, error) {
+				return &truenas.VM{ID: id}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "update_vm", map[string]any{"id": 1, "memory": 8192})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("invalid id returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "update_vm", map[string]any{"id": 0})
+		assertError(t, res, "id must be a positive integer")
+	})
+}
+
+func TestListVMDevices(t *testing.T) {
+	t.Run("returns devices as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			listVMDevicesFn: func(_ context.Context, _ int) ([]truenas.VMDevice, error) {
+				return []truenas.VMDevice{{ID: 1, VMID: 1}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_vm_devices", map[string]any{"id": 1})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("invalid id returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "list_vm_devices", map[string]any{"id": 0})
+		assertError(t, res, "id must be a positive integer")
+	})
+}
+
+func TestAddVMDevice(t *testing.T) {
+	t.Run("returns added device as JSON", func(t *testing.T) {
+		mock := &mockTruenasClient{
+			addVMDeviceFn: func(_ context.Context, p *truenas.AddVMDeviceParams) (*truenas.VMDevice, error) {
+				return &truenas.VMDevice{ID: 10, VMID: p.VMID}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "add_vm_device", map[string]any{
+			"vm_id":      1,
+			"dtype":      "NIC",
+			"attributes": map[string]any{"type": "VIRTIO", "nic_attach": "br0"},
+		})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("invalid vm_id returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "add_vm_device", map[string]any{
+			"vm_id":      0,
+			"dtype":      "NIC",
+			"attributes": map[string]any{},
+		})
+		assertError(t, res, "vm_id must be a positive integer")
+	})
+
+	t.Run("invalid dtype returns error", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockTruenasClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "add_vm_device", map[string]any{
+			"vm_id":      1,
+			"dtype":      "INVALID",
+			"attributes": map[string]any{},
+		})
+		assertError(t, res, "dtype must be one of")
+	})
+}


### PR DESCRIPTION
## Summary

Brings truenas-mcp up to the same quality standard established in proxmox-mcp's hardening pass.

- **`truenasClient` interface** — 35-method interface over `*truenas.Client` in `tools/client_iface.go`; all `register*Tools` functions and `RegisterAll` now accept the interface instead of the concrete type
- **`errorResult()` helper** — per MCP spec §6, tool execution errors now flow as `isError: true` instead of protocol-level errors
- **132 round-trip tool tests** — `mockTruenasClient` with per-method callbacks + `connectTestServer`/`callTool`/assert helpers; tests across all 9 domains (system, pool, dataset, snapshot, vm, app, network, filesystem, destructive)
- **WebSocket message size cap** — `conn.SetReadLimit(10 MiB)` prevents memory exhaustion from abnormally large server frames
- **HTTP server hardening** — `ReadTimeout`, `IdleTimeout`, `MaxHeaderBytes`, `http.MaxBytesHandler` wrapper; `errors.Is(err, http.ErrServerClosed)` fix
- **Makefile tool version pinning** — replaces `@latest` with explicit semver tags to prevent surprise CI breakage
- **Daily CI workflows** — `test-latest.yml` (deps upgrade + test) and `govulncheck.yml` (vulnerability scan)

## Test plan

- [x] `go test -race -count=1 ./...` passes (273 tests: 132 new tool tests + existing 141 internal tests)
- [x] `go build ./...` passes
- [ ] Review `tools/client_iface.go` — interface matches all methods actually called by tool handlers
- [ ] Review test coverage per domain — happy path + error path + input validation
- [ ] Review HTTP hardening in `cmd/truenas-mcp/main.go`
- [ ] Review WebSocket `SetReadLimit` placement in `internal/truenas/client.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)