### PR TITLE
fix: bump Go to 1.26.3 to resolve govulncheck findings

### DIFF
--- a/cmd/truenas-mcp/main.go
+++ b/cmd/truenas-mcp/main.go
@@ -111,8 +111,8 @@ func run() error {
 			ReadHeaderTimeout: 30 * time.Second,
 			// WriteTimeout must exceed the TrueNAS API client timeout (30s) plus
 			// any job-polling time so that in-flight responses are never cut short.
-			WriteTimeout: 90 * time.Second,
-			IdleTimeout:  120 * time.Second,
+			WriteTimeout:   90 * time.Second,
+			IdleTimeout:    120 * time.Second,
 			MaxHeaderBytes: 1 << 20,
 		}
 		slog.Info("truenas-mcp listening", "addr", *addr, "transport", "http")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gordcurrie/truenas-mcp
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/gorilla/websocket v1.5.3

--- a/internal/truenas/client.go
+++ b/internal/truenas/client.go
@@ -17,8 +17,8 @@ import (
 
 const (
 	wsHandshakeTimeout = 10 * time.Second
-	defaultCallTimeout = 30 * time.Second  // applied when ctx has no deadline
-	maxMessageBytes    = 10 * 1024 * 1024  // 10 MiB cap on inbound WebSocket messages
+	defaultCallTimeout = 30 * time.Second // applied when ctx has no deadline
+	maxMessageBytes    = 10 * 1024 * 1024 // 10 MiB cap on inbound WebSocket messages
 )
 
 // rpcRequest is a JSON-RPC 2.0 request frame sent to TrueNAS.

--- a/internal/truenas/dataset.go
+++ b/internal/truenas/dataset.go
@@ -29,21 +29,21 @@ func (v DatasetValue) MarshalJSON() ([]byte, error) {
 
 // Dataset represents a ZFS dataset or zvol on TrueNAS SCALE.
 type Dataset struct {
-	ID          string       `json:"id"`
-	Name        string       `json:"name"`
-	Pool        string       `json:"pool"`
-	Type        string       `json:"type"` // FILESYSTEM or VOLUME
-	MountPoint  *string      `json:"mountpoint,omitempty"`
-	Encrypted   bool         `json:"encrypted"`
-	Available   DatasetValue `json:"available"`
-	Used        DatasetValue `json:"used"`
+	ID         string       `json:"id"`
+	Name       string       `json:"name"`
+	Pool       string       `json:"pool"`
+	Type       string       `json:"type"` // FILESYSTEM or VOLUME
+	MountPoint *string      `json:"mountpoint,omitempty"`
+	Encrypted  bool         `json:"encrypted"`
+	Available  DatasetValue `json:"available"`
+	Used       DatasetValue `json:"used"`
 	// Quota and Comments use omitempty, but because DatasetValue is a struct
 	// omitempty only fires for the exact zero value. In practice TrueNAS returns
 	// a non-zero DatasetValue even for unset quotas ({value:"",rawvalue:"0",...}),
 	// so these fields appear as null (from MarshalJSON) rather than being omitted.
-	Quota       DatasetValue `json:"quota,omitempty"`
+	Quota       DatasetValue `json:"quota"`
 	Compression DatasetValue `json:"compression"`
-	Comments    DatasetValue `json:"comments,omitempty"`
+	Comments    DatasetValue `json:"comments"`
 	Children    []Dataset    `json:"children,omitempty"`
 }
 

--- a/internal/truenas/dataset.go
+++ b/internal/truenas/dataset.go
@@ -37,10 +37,10 @@ type Dataset struct {
 	Encrypted  bool         `json:"encrypted"`
 	Available  DatasetValue `json:"available"`
 	Used       DatasetValue `json:"used"`
-	// Quota and Comments use omitempty, but because DatasetValue is a struct
-	// omitempty only fires for the exact zero value. In practice TrueNAS returns
-	// a non-zero DatasetValue even for unset quotas ({value:"",rawvalue:"0",...}),
-	// so these fields appear as null (from MarshalJSON) rather than being omitted.
+	// Quota and Comments omit omitempty: DatasetValue is a struct, so omitempty
+	// only fires for the exact zero value. TrueNAS returns a non-zero DatasetValue
+	// even for unset quotas ({value:"",rawvalue:"0",...}), so MarshalJSON returns
+	// null for those fields rather than omitting them.
 	Quota       DatasetValue `json:"quota"`
 	Compression DatasetValue `json:"compression"`
 	Comments    DatasetValue `json:"comments"`

--- a/tools/app_test.go
+++ b/tools/app_test.go
@@ -214,7 +214,7 @@ func TestInstallCustomApp(t *testing.T) {
 		defer cleanup()
 
 		res := callTool(t, cs, "install_custom_app", map[string]any{
-			"app_name":                    "my-app",
+			"app_name":                     "my-app",
 			"custom_compose_config_string": "services:\n  web:\n    image: nginx\n",
 		})
 		assertResultJSON(t, res)
@@ -225,7 +225,7 @@ func TestInstallCustomApp(t *testing.T) {
 		defer cleanup()
 
 		res := callTool(t, cs, "install_custom_app", map[string]any{
-			"app_name":                    "",
+			"app_name":                     "",
 			"custom_compose_config_string": "services: {}",
 		})
 		assertError(t, res, "app_name must not be empty")

--- a/tools/mock_client_test.go
+++ b/tools/mock_client_test.go
@@ -18,35 +18,35 @@ type mockTruenasClient struct {
 	getDatasetFn    func(context.Context, string) (*truenas.Dataset, error)
 	createDatasetFn func(context.Context, *truenas.CreateDatasetParams) (*truenas.Dataset, error)
 
-	listSnapshotsFn  func(context.Context, string, ...truenas.ListOptions) ([]truenas.Snapshot, error)
-	getSnapshotFn    func(context.Context, string) (*truenas.Snapshot, error)
-	createSnapshotFn func(context.Context, truenas.CreateSnapshotParams) (*truenas.Snapshot, error)
+	listSnapshotsFn    func(context.Context, string, ...truenas.ListOptions) ([]truenas.Snapshot, error)
+	getSnapshotFn      func(context.Context, string) (*truenas.Snapshot, error)
+	createSnapshotFn   func(context.Context, truenas.CreateSnapshotParams) (*truenas.Snapshot, error)
 	rollbackSnapshotFn func(context.Context, string, truenas.RollbackSnapshotParams) error
-	deleteSnapshotFn func(context.Context, string) error
+	deleteSnapshotFn   func(context.Context, string) error
 
-	listVMsFn      func(context.Context, ...truenas.ListOptions) ([]truenas.VM, error)
-	getVMFn        func(context.Context, int) (*truenas.VM, error)
-	startVMFn      func(context.Context, int) (int, error)
-	stopVMFn       func(context.Context, int, bool) (int, error)
-	restartVMFn    func(context.Context, int) (int, error)
-	createVMFn     func(context.Context, *truenas.CreateVMParams) (*truenas.VM, error)
-	updateVMFn     func(context.Context, int, *truenas.UpdateVMParams) (*truenas.VM, error)
-	deleteVMFn     func(context.Context, int) error
-	listVMDevicesFn func(context.Context, int) ([]truenas.VMDevice, error)
-	addVMDeviceFn  func(context.Context, *truenas.AddVMDeviceParams) (*truenas.VMDevice, error)
+	listVMsFn        func(context.Context, ...truenas.ListOptions) ([]truenas.VM, error)
+	getVMFn          func(context.Context, int) (*truenas.VM, error)
+	startVMFn        func(context.Context, int) (int, error)
+	stopVMFn         func(context.Context, int, bool) (int, error)
+	restartVMFn      func(context.Context, int) (int, error)
+	createVMFn       func(context.Context, *truenas.CreateVMParams) (*truenas.VM, error)
+	updateVMFn       func(context.Context, int, *truenas.UpdateVMParams) (*truenas.VM, error)
+	deleteVMFn       func(context.Context, int) error
+	listVMDevicesFn  func(context.Context, int) ([]truenas.VMDevice, error)
+	addVMDeviceFn    func(context.Context, *truenas.AddVMDeviceParams) (*truenas.VMDevice, error)
 	deleteVMDeviceFn func(context.Context, int) error
 
-	listAppsFn       func(context.Context, ...truenas.ListOptions) ([]truenas.App, error)
-	getAppFn         func(context.Context, string) (*truenas.App, error)
-	startAppFn       func(context.Context, string) (int, error)
-	stopAppFn        func(context.Context, string) (int, error)
-	restartAppFn     func(context.Context, string) (int, error)
-	listImagesFn     func(context.Context) ([]truenas.Image, error)
-	createAppFn      func(context.Context, *truenas.CreateAppParams) (int, error)
-	deleteAppFn      func(context.Context, string) error
-	upgradeAppFn     func(context.Context, string, string) (int, error)
+	listAppsFn          func(context.Context, ...truenas.ListOptions) ([]truenas.App, error)
+	getAppFn            func(context.Context, string) (*truenas.App, error)
+	startAppFn          func(context.Context, string) (int, error)
+	stopAppFn           func(context.Context, string) (int, error)
+	restartAppFn        func(context.Context, string) (int, error)
+	listImagesFn        func(context.Context) ([]truenas.Image, error)
+	createAppFn         func(context.Context, *truenas.CreateAppParams) (int, error)
+	deleteAppFn         func(context.Context, string) error
+	upgradeAppFn        func(context.Context, string, string) (int, error)
 	getUpgradeSummaryFn func(context.Context, string) (*truenas.AppUpgradeSummary, error)
-	rollbackAppFn    func(context.Context, string, string) (int, error)
+	rollbackAppFn       func(context.Context, string, string) (int, error)
 
 	listInterfacesFn func(context.Context) ([]truenas.Interface, error)
 	listDirectoryFn  func(context.Context, string) ([]truenas.DirEntry, error)


### PR DESCRIPTION
## Summary

- Bumps `go` directive in `go.mod` from `1.26.2` → `1.26.3`
- Fixes two stdlib vulnerabilities identified by `govulncheck`:
  - **GO-2026-4971** — panic in `net.Dial`/`LookupPort` on NUL byte (Windows)
  - **GO-2026-4918** — infinite loop in `net/http` HTTP/2 transport on bad `SETTINGS_MAX_FRAME_SIZE`
- Also commits formatting fixes applied by `go fix ./...` and `gofumpt` during `make check` (alignment-only except two `omitempty` removals on `DatasetValue` struct fields where it had no effect per the existing code comment)

## Test plan

- [x] `govulncheck ./...` — no vulnerabilities found
- [x] `make check` — all gates pass (fix, fmt, vet, lint, sec, vulncheck, test, build)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)