### PR TITLE
fix: bump Go to 1.26.4 to resolve govulncheck findings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gordcurrie/truenas-mcp
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
## Summary
- Bumps Go from 1.26.3 → 1.26.4 in `go.mod`
- Fixes GO-2026-5037 (`crypto/x509` — inefficient hostname parsing), reachable via `websocket.Dialer.DialContext` → `x509.Certificate.Verify`
- Fixes GO-2026-5039 (`net/textproto` — unescaped inputs in errors), reachable via `websocket.Dialer.DialContext` → `textproto.Reader.ReadMIMEHeader`

## Test plan
- [ ] `govulncheck ./...` reports 0 symbol vulnerabilities
- [ ] CI / govulncheck workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)