### PR TITLE
ci: bump actions to node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -9,10 +9,10 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,9 @@ jobs:
             goarch: amd64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -50,7 +50,7 @@ jobs:
             ./cmd/truenas-mcp
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: truenas-mcp_${{ matrix.goos }}_${{ matrix.goarch }}
           path: dist/truenas-mcp_${{ matrix.goos }}_${{ matrix.goarch }}*
@@ -65,13 +65,13 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: dist/
           merge-multiple: true
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true

--- a/.github/workflows/test-latest.yml
+++ b/.github/workflows/test-latest.yml
@@ -9,10 +9,10 @@ jobs:
   test-latest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` v4 → v5
- Bump `actions/setup-go` v5 → v6
- Bump `actions/upload-artifact` v4 → v6
- Bump `actions/download-artifact` v4 → v6
- Bump `softprops/action-gh-release` v2 → v3

GitHub deprecated node20 actions runners on June 2, 2026. All updated versions run on node24.

## Test plan

- [ ] CI passes on this PR
- [ ] Release workflow runs correctly on next tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)