### PR TITLE
fix: bump Go to 1.26.5 to resolve govulncheck finding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gordcurrie/truenas-mcp
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
## Summary
- govulncheck flagged GO-2026-5856, an Encrypted Client Hello privacy leak in `crypto/tls`, affecting the Go 1.26.4 standard library
- Bumps `go.mod` to Go 1.26.5, which fixes the vulnerability
- All CI workflows use `go-version-file: go.mod`, so no other files needed changes

## Test plan
- [x] `govulncheck ./...` now reports 0 vulnerabilities (previously 1 stdlib finding, exit code 3)
- [x] `go build ./...` succeeds with the new toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)